### PR TITLE
Use OpenAI DALL-E 3 for story illustrations for now

### DIFF
--- a/myproject/public/js/createStory.js
+++ b/myproject/public/js/createStory.js
@@ -176,7 +176,7 @@ document.addEventListener('DOMContentLoaded', function() {
     generateFineTunedStoryButton.addEventListener('click', async function() {
         const genre = document.getElementById('genre').value;
         const length = document.getElementById('length').value;
-        const characterNum = document.getElementById('characterNum').value;
+        const characterNum = document.getElementById('characterNum').value || '2';
         const emotion = document.getElementById('emotion').value;
         const language = document.getElementById('language').value;
     

--- a/myproject/server.js
+++ b/myproject/server.js
@@ -200,22 +200,17 @@ app.post('/generate-story', async (req, res) => {
             .split('|')
             .map((part) => part.trim());
 
-        const generation = await higgsfield.subscribe('/v1/text2image/soul', {
-            input: {
-                prompt: (imagePrompt || story).substring(0, 1000),
-                width_and_height: '1536x1536',
-                quality: '1080p',
-                batch_size: 1,
-                enhance_prompt: true,
-            },
-            withPolling: true,
+        // Image via OpenAI DALL-E 3 for now. To switch back to Higgsfield Soul
+        // (needs platform.higgsfield.ai developer keys in HF_CREDENTIALS):
+        // higgsfield.subscribe('/v1/text2image/soul', { input: { prompt, ... }, withPolling: true })
+        const imageResponse = await openai.images.generate({
+            model: 'dall-e-3',
+            prompt: (imagePrompt || story).substring(0, 1000),
+            n: 1,
+            size: '1024x1024',
         });
 
-        if (generation.status !== 'completed' || !generation.images?.length) {
-            throw new Error(`Higgsfield image generation ${generation.status}`);
-        }
-
-        res.json({ story, imageUrl: generation.images[0].url });
+        res.json({ story, imageUrl: imageResponse.data[0].url });
     } catch (error) {
         console.error('Error generating story and image:', error);
         res.status(500).send({ error: 'Failed to generate story and image' });

--- a/myproject/worker/index.js
+++ b/myproject/worker/index.js
@@ -127,7 +127,27 @@ async function handleSpeech(env, body) {
     });
 }
 
+// OpenAI DALL-E 3 text-to-image (current image provider).
+async function generateIllustrationOpenAI(env, prompt) {
+    const resp = await fetch('https://api.openai.com/v1/images/generations', {
+        method: 'POST',
+        headers: {
+            'Authorization': `Bearer ${env.OPENAI_API_KEY}`,
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ model: 'dall-e-3', prompt, n: 1, size: '1024x1024' }),
+    });
+    if (!resp.ok) {
+        throw new Error(`OpenAI image generation failed (${resp.status}): ${await resp.text()}`);
+    }
+    const data = await resp.json();
+    const url = data.data?.[0]?.url;
+    if (!url) throw new Error('OpenAI image generation returned no URL');
+    return url;
+}
+
 // Higgsfield Soul text-to-image via REST: submit, then poll to completion.
+// Kept for when HF_CREDENTIALS (platform.higgsfield.ai developer keys) are set up.
 async function generateIllustration(env, prompt) {
     const auth = { 'Authorization': `Key ${env.HF_CREDENTIALS}`, 'Content-Type': 'application/json' };
 
@@ -179,7 +199,7 @@ async function handleGenerateStory(env, anthropic, body) {
         .split('|')
         .map((part) => part.trim());
 
-    const imageUrl = await generateIllustration(env, (imagePrompt || story).substring(0, 1000));
+    const imageUrl = await generateIllustrationOpenAI(env, (imagePrompt || story).substring(0, 1000));
     return json({ story, imageUrl });
 }
 


### PR DESCRIPTION
`/generate-story` was 500ing on the image step — the Higgsfield platform API needs separate developer credentials (platform.higgsfield.ai) from the consumer subscription. This switches story illustrations to OpenAI DALL-E 3 using the already-working `OPENAI_API_KEY`, in both the Worker and the Express server.

The Higgsfield Soul code path stays in place (commented/unused) for an easy switch back once real `HF_CREDENTIALS` platform keys exist.

No new secrets needed — merging this auto-deploys and story generation should work immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZwfTtXwtJMbZFNryxzSUR

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZwfTtXwtJMbZFNryxzSUR)_