### PR TITLE
Surface real error details on /generate-story failures

### DIFF
--- a/myproject/public/js/createStory.js
+++ b/myproject/public/js/createStory.js
@@ -47,7 +47,9 @@ async function generateStory(prompt) {
         });
 
         if (!response.ok) {
-            throw new Error(`Server error: ${response.statusText}`);
+            const errBody = await response.text().catch(() => '');
+            console.error('Server error body:', errBody);
+            throw new Error(`Server error ${response.status}: ${errBody}`);
         }
 
         const data = await response.json();

--- a/myproject/worker/index.js
+++ b/myproject/worker/index.js
@@ -208,9 +208,9 @@ export default {
         const url = new URL(request.url);
         const path = url.pathname;
         const method = request.method;
-        const anthropic = new Anthropic({ apiKey: env.ANTHROPIC_API_KEY });
 
         try {
+            const anthropic = new Anthropic({ apiKey: env.ANTHROPIC_API_KEY });
             if (method === 'POST') {
                 const body = await request.json().catch(() => ({}));
 
@@ -230,7 +230,9 @@ export default {
             return json({ error: 'Not found' }, 404);
         } catch (error) {
             console.error(`Error handling ${method} ${path}:`, error);
-            return json({ error: 'Internal error' }, 500);
+            // Surface the underlying cause so failures are debuggable from the
+            // browser Network tab (no key material is ever in these messages).
+            return json({ error: 'Internal error', detail: String(error?.message || error) }, 500);
         }
     },
 };


### PR DESCRIPTION
Story generation still 500s after the DALL-E switch, but the worker was returning a bare `{"error":"Internal error"}` with no cause. This change:

- includes the underlying error message in the 500 response body (never any key material)
- moves the Anthropic client construction inside the try/catch so a missing/misnamed secret produces a readable error instead of an opaque crash
- makes the frontend log the response body on failure

After merging + auto-deploy, clicking Generate will print the actual failing call (Anthropic auth, model access, DALL-E, etc.) in the browser console — paste that line and the fix will be obvious.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZwfTtXwtJMbZFNryxzSUR

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZwfTtXwtJMbZFNryxzSUR)_