### PR TITLE
Switch images to gpt-image-2, Claude to Haiku 4.5

### DIFF
--- a/myproject/server.js
+++ b/myproject/server.js
@@ -16,7 +16,7 @@ const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 // OpenAI is kept for text-to-speech only (Claude does not generate audio).
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
-const CLAUDE_MODEL = 'claude-opus-4-8';
+const CLAUDE_MODEL = 'claude-haiku-4-5'; // cheapest tier; swap to 'claude-sonnet-5' or 'claude-opus-4-8' for higher quality
 
 // Extract the plain text from a Claude response (skips thinking blocks).
 function claudeText(message) {
@@ -189,7 +189,6 @@ app.post('/generate-story', async (req, res) => {
         const message = await anthropic.messages.create({
             model: CLAUDE_MODEL,
             max_tokens: 8192,
-            thinking: { type: 'adaptive' },
             system: 'You are a helpful assistant designed to write short stories and suitable image prompts in plain text format: story|imagePrompt. Output exactly one "|" separating the story from the image prompt, and nothing else.',
             messages: [
                 { role: 'user', content: prompt }
@@ -200,17 +199,16 @@ app.post('/generate-story', async (req, res) => {
             .split('|')
             .map((part) => part.trim());
 
-        // Image via OpenAI DALL-E 3 for now. To switch back to Higgsfield Soul
-        // (needs platform.higgsfield.ai developer keys in HF_CREDENTIALS):
+        // Image via OpenAI GPT Image (returns base64 -> served as a data URL).
+        // To switch back to Higgsfield Soul (needs platform.higgsfield.ai keys):
         // higgsfield.subscribe('/v1/text2image/soul', { input: { prompt, ... }, withPolling: true })
         const imageResponse = await openai.images.generate({
-            model: 'dall-e-3',
+            model: 'gpt-image-2',
             prompt: (imagePrompt || story).substring(0, 1000),
-            n: 1,
             size: '1024x1024',
         });
 
-        res.json({ story, imageUrl: imageResponse.data[0].url });
+        res.json({ story, imageUrl: `data:image/png;base64,${imageResponse.data[0].b64_json}` });
     } catch (error) {
         console.error('Error generating story and image:', error);
         res.status(500).send({ error: 'Failed to generate story and image' });

--- a/myproject/worker/index.js
+++ b/myproject/worker/index.js
@@ -9,7 +9,7 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 
-const CLAUDE_MODEL = 'claude-opus-4-8';
+const CLAUDE_MODEL = 'claude-haiku-4-5'; // cheapest tier; swap to 'claude-sonnet-5' or 'claude-opus-4-8' for higher quality
 const HIGGSFIELD_BASE = 'https://platform.higgsfield.ai';
 
 function json(data, status = 200) {
@@ -127,7 +127,8 @@ async function handleSpeech(env, body) {
     });
 }
 
-// OpenAI DALL-E 3 text-to-image (current image provider).
+// OpenAI GPT Image text-to-image (current image provider).
+// GPT Image models return base64, not a hosted URL, so we hand back a data URL.
 async function generateIllustrationOpenAI(env, prompt) {
     const resp = await fetch('https://api.openai.com/v1/images/generations', {
         method: 'POST',
@@ -135,15 +136,15 @@ async function generateIllustrationOpenAI(env, prompt) {
             'Authorization': `Bearer ${env.OPENAI_API_KEY}`,
             'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ model: 'dall-e-3', prompt, n: 1, size: '1024x1024' }),
+        body: JSON.stringify({ model: 'gpt-image-2', prompt, size: '1024x1024' }),
     });
     if (!resp.ok) {
         throw new Error(`OpenAI image generation failed (${resp.status}): ${await resp.text()}`);
     }
     const data = await resp.json();
-    const url = data.data?.[0]?.url;
-    if (!url) throw new Error('OpenAI image generation returned no URL');
-    return url;
+    const b64 = data.data?.[0]?.b64_json;
+    if (!b64) throw new Error('OpenAI image generation returned no image data');
+    return `data:image/png;base64,${b64}`;
 }
 
 // Higgsfield Soul text-to-image via REST: submit, then poll to completion.
@@ -190,7 +191,6 @@ async function handleGenerateStory(env, anthropic, body) {
     const message = await anthropic.messages.create({
         model: CLAUDE_MODEL,
         max_tokens: 8192,
-        thinking: { type: 'adaptive' },
         system: 'You are a helpful assistant designed to write short stories and suitable image prompts in plain text format: story|imagePrompt. Output exactly one "|" separating the story from the image prompt, and nothing else.',
         messages: [{ role: 'user', content: prompt }],
     });


### PR DESCRIPTION
Two fixes from live testing:

- **Images:** DALL-E 3 is deprecated upstream and the image request 400'd. Story illustrations now use **gpt-image-2** (OpenAI's current image model). GPT Image returns base64 rather than a hosted URL, so `/generate-story` responds with a `data:image/png;base64,...` URL that the existing `<img>` rendering handles unchanged — in both the Worker and Express.
- **Cost:** Claude model switched to **`claude-haiku-4-5`** (cheapest tier, $1/$5 per MTok) for definitions, translation, and story text; the adaptive-thinking parameter is removed since Haiku doesn't support it. The model is one constant per file — swap to `claude-sonnet-5` or `claude-opus-4-8` any time quality feels lacking.

Merging auto-deploys; then Generate Story should work end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZwfTtXwtJMbZFNryxzSUR

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZwfTtXwtJMbZFNryxzSUR)_