### PR TITLE
Polish redesign: parallax stars, more covers, translate guardrails, quick guide

### DIFF
--- a/myproject/public/create-story.html
+++ b/myproject/public/create-story.html
@@ -159,5 +159,6 @@
         </div>
     </footer>
     <script src="js/createStory.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 </body>
 </html>

--- a/myproject/public/css/style.css
+++ b/myproject/public/css/style.css
@@ -43,9 +43,14 @@ a:hover { color: #E9E4FF; }
     50% { transform: translateY(-10px); }
 }
 
+@keyframes floaty-lg {
+    0%, 100% { transform: translateY(0) rotate(var(--tilt, 0deg)); }
+    50% { transform: translateY(-20px) rotate(var(--tilt, 0deg)); }
+}
+
 @keyframes twinkle {
-    0%, 100% { opacity: 0.25; }
-    50% { opacity: 0.9; }
+    0%, 100% { opacity: 0.12; transform: scale(0.8); }
+    50% { opacity: 1; transform: scale(1.15); }
 }
 
 @keyframes fadeIn {
@@ -306,12 +311,14 @@ header { background: transparent; }
     width: 185px;
     border-radius: 14px;
     box-shadow: 0 18px 44px rgba(0, 0, 0, 0.55), 0 0 0 1px rgba(255, 255, 255, 0.1);
-    animation: floaty 7s ease-in-out infinite;
+    animation: floaty-lg 6s ease-in-out infinite;
     z-index: 1;
 }
 
-.hero-float.left { left: 3%; top: 24%; transform: rotate(-7deg); }
-.hero-float.right { right: 3%; top: 36%; transform: rotate(6deg); animation-duration: 8s; animation-delay: 1s; }
+.hero-float.left { --tilt: -7deg; left: 3%; top: 20%; }
+.hero-float.right { --tilt: 6deg; right: 3%; top: 30%; animation-duration: 7s; animation-delay: 1s; }
+.hero-float.bottom-left { --tilt: 5deg; left: 9%; top: 68%; width: 150px; animation-duration: 8s; animation-delay: 0.5s; }
+.hero-float.bottom-right { --tilt: -5deg; right: 9%; top: 70%; width: 150px; animation-duration: 6.5s; animation-delay: 1.6s; }
 
 .star-field {
     position: absolute;
@@ -320,16 +327,35 @@ header { background: transparent; }
     overflow: hidden;
 }
 
-.star-field span {
+.star-field .star {
     position: absolute;
-    color: var(--lavender);
-    animation: twinkle 3s infinite, floaty 7s ease-in-out infinite;
+    transition: transform 0.4s ease-out;
+    will-change: transform;
 }
 
-.star-field span.gold { color: var(--amber); }
+.star-field .star i {
+    font-style: normal;
+    display: inline-block;
+    color: var(--lavender);
+    animation-name: twinkle, floaty;
+    animation-iteration-count: infinite, infinite;
+    animation-timing-function: ease-in-out, ease-in-out;
+}
 
+.star-field .star.gold i { color: var(--amber); }
+
+/* On smaller screens keep two covers, faded behind the hero text */
 @media (max-width: 1240px) {
-    .hero-float { display: none; }
+    .hero-float.bottom-left, .hero-float.bottom-right { display: none; }
+
+    .hero-float.left, .hero-float.right {
+        z-index: 0;
+        opacity: 0.3;
+        width: 150px;
+    }
+
+    .hero-float.left { left: -30px; top: 12%; }
+    .hero-float.right { right: -30px; top: 55%; }
 }
 
 /* ---------- Page header (Library / Create Story) ---------- */
@@ -908,6 +934,68 @@ fieldset.extras legend {
     color: var(--text-muted);
 }
 
+.popup .def-body h4 {
+    margin: 14px 0 4px;
+    font-family: 'Karla', sans-serif;
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--lavender);
+}
+
+/* ---------- Quick guide ---------- */
+.key-guide {
+    max-width: 1080px;
+    width: 100%;
+    margin: 70px auto 0;
+    padding: 28px 30px;
+    border-radius: 24px;
+    background: linear-gradient(170deg, var(--bg-raise), var(--bg-raise-2));
+    border: 1px solid rgba(139, 92, 246, 0.25);
+    box-sizing: border-box;
+}
+
+.key-guide h3 { margin: 0 0 18px; font-size: 20px; }
+
+.key-guide ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 14px 28px;
+}
+
+.key-guide li {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    font-size: 14px;
+    line-height: 1.55;
+    color: var(--text-muted);
+}
+
+.key-chip {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 12px;
+    border-radius: 999px;
+    background: rgba(139, 92, 246, 0.15);
+    border: 1px solid var(--line-strong);
+    color: var(--lavender);
+    font-size: 13px;
+    font-weight: 700;
+    white-space: nowrap;
+}
+
+@media (max-width: 900px) {
+    .key-guide { margin: 40px 20px 0; width: auto; }
+    .key-guide ul { grid-template-columns: 1fr; }
+}
+
 /* ---------- Footer ---------- */
 footer {
     margin-top: 90px;
@@ -1010,6 +1098,8 @@ footer button#aboutButton:hover { color: #fff; transform: none; box-shadow: none
     top: 20%;
     left: 50%;
     transform: translate(-50%, -20%);
+    max-height: 65vh;
+    overflow-y: auto;
     background: #171130;
     color: var(--text);
     border: 1px solid var(--line-strong);
@@ -1056,6 +1146,18 @@ footer button#aboutButton:hover { color: #fff; transform: none; box-shadow: none
     cursor: pointer;
     margin-left: 10px;
 }
+
+/* ---------- SweetAlert2 dark theme ---------- */
+.swal2-popup {
+    background: #171130 !important;
+    color: var(--text) !important;
+    border: 1px solid var(--line-strong);
+    border-radius: 16px !important;
+    font-family: 'Karla', sans-serif;
+}
+
+.swal2-title { color: #fff !important; font-family: 'Young Serif', serif; font-weight: 400 !important; }
+.swal2-html-container { color: var(--text-muted) !important; }
 
 /* ---------- Language flags (typewriter intro) ---------- */
 .us, .fr, .de, .es, .cn, .ar {

--- a/myproject/public/index.html
+++ b/myproject/public/index.html
@@ -38,22 +38,30 @@
         </div>
     </header>
     <section class="hero">
-        <div class="star-field" aria-hidden="true">
-            <span style="top:8%; left:12%; font-size:11px; animation-delay:0.2s;">✦</span>
-            <span class="gold" style="top:18%; left:28%; font-size:8px; animation-delay:1.1s;">✦</span>
-            <span style="top:6%; left:58%; font-size:9px; animation-delay:2s;">✦</span>
-            <span style="top:22%; left:72%; font-size:12px; animation-delay:0.6s;">✦</span>
-            <span class="gold" style="top:44%; left:8%; font-size:9px; animation-delay:1.6s;">✦</span>
-            <span style="top:60%; left:20%; font-size:8px; animation-delay:2.4s;">✦</span>
-            <span style="top:38%; left:88%; font-size:10px; animation-delay:0.9s;">✦</span>
-            <span class="gold" style="top:66%; left:80%; font-size:11px; animation-delay:1.9s;">✦</span>
-            <span style="top:76%; left:44%; font-size:8px; animation-delay:0.4s;">✦</span>
-            <span style="top:12%; left:42%; font-size:8px; animation-delay:2.8s;">✦</span>
-            <span class="gold" style="top:52%; left:60%; font-size:9px; animation-delay:1.3s;">✦</span>
-            <span style="top:80%; left:64%; font-size:10px; animation-delay:2.2s;">✦</span>
+        <div id="star-field" class="star-field" aria-hidden="true">
+            <span class="star" data-depth="1.2" style="top:8%; left:12%;"><i style="font-size:11px; animation-duration:2.6s,5.5s; animation-delay:0.2s,0.4s;">✦</i></span>
+            <span class="star gold" data-depth="0.6" style="top:18%; left:28%;"><i style="font-size:8px; animation-duration:3.4s,7s; animation-delay:1.1s,1.8s;">✦</i></span>
+            <span class="star" data-depth="0.9" style="top:6%; left:58%;"><i style="font-size:9px; animation-duration:2.9s,6.2s; animation-delay:2s,0.7s;">✦</i></span>
+            <span class="star" data-depth="1.4" style="top:22%; left:72%;"><i style="font-size:13px; animation-duration:2.4s,5s; animation-delay:0.6s,2.1s;">✦</i></span>
+            <span class="star gold" data-depth="0.7" style="top:44%; left:8%;"><i style="font-size:9px; animation-duration:3.8s,7.6s; animation-delay:1.6s,0.3s;">✦</i></span>
+            <span class="star" data-depth="0.5" style="top:60%; left:20%;"><i style="font-size:8px; animation-duration:3.1s,6.8s; animation-delay:2.4s,1.2s;">✦</i></span>
+            <span class="star" data-depth="1.1" style="top:38%; left:88%;"><i style="font-size:10px; animation-duration:2.7s,5.8s; animation-delay:0.9s,2.6s;">✦</i></span>
+            <span class="star gold" data-depth="1.3" style="top:66%; left:80%;"><i style="font-size:12px; animation-duration:2.5s,5.2s; animation-delay:1.9s,0.9s;">✦</i></span>
+            <span class="star" data-depth="0.8" style="top:76%; left:44%;"><i style="font-size:8px; animation-duration:3.6s,7.2s; animation-delay:0.4s,1.5s;">✦</i></span>
+            <span class="star" data-depth="0.6" style="top:12%; left:42%;"><i style="font-size:8px; animation-duration:3.3s,6.5s; animation-delay:2.8s,0.2s;">✦</i></span>
+            <span class="star gold" data-depth="1.0" style="top:52%; left:60%;"><i style="font-size:9px; animation-duration:2.8s,6s; animation-delay:1.3s,2.3s;">✦</i></span>
+            <span class="star" data-depth="1.2" style="top:80%; left:64%;"><i style="font-size:11px; animation-duration:2.6s,5.4s; animation-delay:2.2s,1s;">✦</i></span>
+            <span class="star" data-depth="0.9" style="top:30%; left:16%;"><i style="font-size:9px; animation-duration:3s,6.4s; animation-delay:0.8s,1.7s;">✦</i></span>
+            <span class="star gold" data-depth="1.5" style="top:10%; left:82%;"><i style="font-size:12px; animation-duration:2.3s,4.8s; animation-delay:1.4s,0.6s;">✦</i></span>
+            <span class="star" data-depth="0.7" style="top:70%; left:8%;"><i style="font-size:8px; animation-duration:3.5s,7.4s; animation-delay:2.6s,2s;">✦</i></span>
+            <span class="star" data-depth="1.1" style="top:86%; left:26%;"><i style="font-size:10px; animation-duration:2.9s,5.6s; animation-delay:0.5s,1.1s;">✦</i></span>
+            <span class="star gold" data-depth="0.8" style="top:34%; left:50%;"><i style="font-size:8px; animation-duration:3.2s,6.6s; animation-delay:1.8s,0.8s;">✦</i></span>
+            <span class="star" data-depth="1.3" style="top:58%; left:92%;"><i style="font-size:11px; animation-duration:2.5s,5.1s; animation-delay:2.1s,1.4s;">✦</i></span>
         </div>
         <img src="images/covers/story_2.webp" alt="" class="hero-float left">
         <img src="images/covers/story_10.webp" alt="" class="hero-float right">
+        <img src="images/covers/story_3.webp" alt="" class="hero-float bottom-left">
+        <img src="images/covers/story_7.webp" alt="" class="hero-float bottom-right">
         <div class="hero-inner">
             <span class="hero-badge">✨ AI-powered language learning</span>
             <h1 class="hero-title">Learn a language through <span class="gradient-text">stories you'll actually love</span></h1>
@@ -135,6 +143,17 @@
             <a href="library.html" class="browse-all">Browse all stories →</a>
         </aside>
     </main>
+    <section class="key-guide">
+        <h3>🔑 Quick guide</h3>
+        <ul>
+            <li><span class="key-chip">📖 Read</span><span>Pick any story from the <a href="library.html">Library</a> — or start with the featured one above.</span></li>
+            <li><span class="key-chip">🔊 Read aloud</span><span>Choose one of six voices and listen to the story narrated.</span></li>
+            <li><span class="key-chip">🎙 Record</span><span>Narrate the story yourself and play back your recording.</span></li>
+            <li><span class="key-chip">👆 Double-click</span><span>Double-click any word for its definition and pronunciation.</span></li>
+            <li><span class="key-chip">T&nbsp;Translate</span><span>Turn on the <strong>T</strong> toggle and pick "I speak…" — then double-click words or press Translate.</span></li>
+            <li><span class="key-chip">✨ Create</span><span>Generate your own illustrated story on the <a href="create-story.html">Create Story</a> page.</span></li>
+        </ul>
+    </section>
     <footer>
         <span class="footer-brand">✦ LISA 1000</span>
         <div class="footer-links">

--- a/myproject/public/js/createStory.js
+++ b/myproject/public/js/createStory.js
@@ -1,3 +1,12 @@
+// Small toast-style notice (SweetAlert2 when available, alert() otherwise)
+function notifyUser(title, text) {
+    if (window.Swal) {
+        Swal.fire({ icon: 'info', title: title, text: text, confirmButtonColor: '#8B5CF6' });
+    } else {
+        alert(title + '\n' + text);
+    }
+}
+
 function languageName(lang, otherLanguage) {
     switch (lang) {
         case 'fr': return 'French';
@@ -228,10 +237,19 @@ document.addEventListener('DOMContentLoaded', function() {
         readStoryAloud(storyText, selectedVoice);
     });
     translateButton.addEventListener('click', async function() {
+        const translationToggle = document.getElementById('translation-toggle').classList.contains('active');
+        if (!translationToggle) {
+            notifyUser('Turn on Translate mode', 'Click the T toggle in the navigation bar to enable translation, then press Translate again.');
+            return;
+        }
         const storyText = document.getElementById('story-content').textContent;
         let targetLanguage = document.getElementById('nativeLanguage').value;
         if (targetLanguage === 'other') {
             targetLanguage = document.getElementById('otherLanguage').value.trim();
+        }
+        if (!targetLanguage || targetLanguage === 'default') {
+            notifyUser('Pick your language', 'Choose your language in the "I speak…" dropdown so we know what to translate into.');
+            return;
         }
         if (targetLanguage && targetLanguage !== 'default') {
             translateButton.disabled = true;
@@ -330,11 +348,22 @@ async function defineText(word) {
     }
 }
 
+// Convert the lightweight markdown Claude returns (## headings, **bold**) to HTML
+function formatDefinitionText(text) {
+    return (text || '')
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+        .replace(/^#{1,4}\s*(.+)$/gm, '<h4>$1</h4>')
+        .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+        .replace(/\n{2,}/g, '<br>')
+        .replace(/\n/g, '<br>')
+        .replace(/<\/h4><br>/g, '</h4>');
+}
+
 // Build popup HTML for a definition entry (word, phonetic, audio, meanings)
 function renderDefinition(entry) {
     const meanings = (entry.meanings && entry.meanings.length)
         ? entry.meanings.map(m => `<p><em>${m.partOfSpeech}</em> — ${m.definition}${m.example ? `<br><span class="def-example">"${m.example}"</span>` : ''}</p>`).join('')
-        : `<p>${(entry.definition || '').replace(/\n/g, '<br>')}</p>`;
+        : `<div class="def-body">${formatDefinitionText(entry.definition)}</div>`;
     const audio = entry.audioUrl
         ? `<button class="pronounce-btn" onclick="new Audio('${entry.audioUrl}').play()">🔊 Pronounce</button>`
         : '';

--- a/myproject/public/js/loadStories.js
+++ b/myproject/public/js/loadStories.js
@@ -82,11 +82,22 @@ async function defineText(word) {
     }
 }
 
+// Convert the lightweight markdown Claude returns (## headings, **bold**) to HTML
+function formatDefinitionText(text) {
+    return (text || '')
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+        .replace(/^#{1,4}\s*(.+)$/gm, '<h4>$1</h4>')
+        .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+        .replace(/\n{2,}/g, '<br>')
+        .replace(/\n/g, '<br>')
+        .replace(/<\/h4><br>/g, '</h4>');
+}
+
 // Build popup HTML for a definition entry (word, phonetic, audio, meanings)
 function renderDefinition(entry) {
     const meanings = (entry.meanings && entry.meanings.length)
         ? entry.meanings.map(m => `<p><em>${m.partOfSpeech}</em> — ${m.definition}${m.example ? `<br><span class="def-example">"${m.example}"</span>` : ''}</p>`).join('')
-        : `<p>${(entry.definition || '').replace(/\n/g, '<br>')}</p>`;
+        : `<div class="def-body">${formatDefinitionText(entry.definition)}</div>`;
     const audio = entry.audioUrl
         ? `<button class="pronounce-btn" onclick="new Audio('${entry.audioUrl}').play()">🔊 Pronounce</button>`
         : '';

--- a/myproject/public/js/script.js
+++ b/myproject/public/js/script.js
@@ -85,6 +85,31 @@ function cycleText() {
 
 window.onload = cycleText;
 
+// Parallax: stars drift away from the cursor, scaled by their depth
+document.addEventListener('DOMContentLoaded', function() {
+    const starField = document.getElementById('star-field');
+    if (!starField) return;
+    const stars = starField.querySelectorAll('[data-depth]');
+    window.addEventListener('mousemove', function(e) {
+        const r = starField.getBoundingClientRect();
+        const dx = (e.clientX - (r.left + r.width / 2)) / r.width;
+        const dy = (e.clientY - (r.top + r.height / 2)) / r.height;
+        stars.forEach(star => {
+            const depth = parseFloat(star.getAttribute('data-depth'));
+            star.style.transform = `translate(${(dx * depth * -26).toFixed(1)}px, ${(dy * depth * -18).toFixed(1)}px)`;
+        });
+    });
+});
+
+// Small toast-style notice (SweetAlert2 when available, alert() otherwise)
+function notifyUser(title, text) {
+    if (window.Swal) {
+        Swal.fire({ icon: 'info', title: title, text: text, confirmButtonColor: '#8B5CF6' });
+    } else {
+        alert(title + '\n' + text);
+    }
+}
+
 // Function to read the story aloud
 async function readStoryAloud(text, voice) {
     try {
@@ -151,11 +176,22 @@ async function defineText(word) {
     }
 }
 
+// Convert the lightweight markdown Claude returns (## headings, **bold**) to HTML
+function formatDefinitionText(text) {
+    return (text || '')
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+        .replace(/^#{1,4}\s*(.+)$/gm, '<h4>$1</h4>')
+        .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+        .replace(/\n{2,}/g, '<br>')
+        .replace(/\n/g, '<br>')
+        .replace(/<\/h4><br>/g, '</h4>');
+}
+
 // Build popup HTML for a definition entry (word, phonetic, audio, meanings)
 function renderDefinition(entry) {
     const meanings = (entry.meanings && entry.meanings.length)
         ? entry.meanings.map(m => `<p><em>${m.partOfSpeech}</em> — ${m.definition}${m.example ? `<br><span class="def-example">"${m.example}"</span>` : ''}</p>`).join('')
-        : `<p>${(entry.definition || '').replace(/\n/g, '<br>')}</p>`;
+        : `<div class="def-body">${formatDefinitionText(entry.definition)}</div>`;
     const audio = entry.audioUrl
         ? `<button class="pronounce-btn" onclick="new Audio('${entry.audioUrl}').play()">🔊 Pronounce</button>`
         : '';
@@ -261,7 +297,7 @@ function showTranslation(selectedText, translation) {
 async function translateStory() {
     const translationToggle = document.getElementById('translation-toggle').classList.contains('active');
     if (!translationToggle) {
-        console.log('Translation toggle is not active. Translation not triggered.');
+        notifyUser('Turn on Translate mode', 'Click the T toggle in the navigation bar to enable translation, then press Translate again.');
         return;
     }
 
@@ -271,6 +307,11 @@ async function translateStory() {
 
     if (targetLanguage === 'other') {
         targetLanguage = document.getElementById('otherLanguage').value.trim();
+    }
+
+    if (!targetLanguage || targetLanguage === 'default') {
+        notifyUser('Pick your language', 'Choose your language in the "I speak…" dropdown so we know what to translate into.');
+        return;
     }
 
     if (targetLanguage && targetLanguage !== 'default') {

--- a/myproject/server.js
+++ b/myproject/server.js
@@ -16,7 +16,7 @@ const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 // OpenAI is kept for text-to-speech only (Claude does not generate audio).
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
-const CLAUDE_MODEL = 'claude-haiku-4-5'; // cheapest tier; swap to 'claude-sonnet-5' or 'claude-opus-4-8' for higher quality
+const CLAUDE_MODEL = 'claude-sonnet-5'; // swap to 'claude-haiku-4-5' (cheaper) or 'claude-opus-4-8' (higher quality)
 
 // Extract the plain text from a Claude response (skips thinking blocks).
 function claudeText(message) {

--- a/myproject/worker/index.js
+++ b/myproject/worker/index.js
@@ -9,7 +9,7 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 
-const CLAUDE_MODEL = 'claude-haiku-4-5'; // cheapest tier; swap to 'claude-sonnet-5' or 'claude-opus-4-8' for higher quality
+const CLAUDE_MODEL = 'claude-sonnet-5'; // swap to 'claude-haiku-4-5' (cheaper) or 'claude-opus-4-8' (higher quality)
 const HIGGSFIELD_BASE = 'https://platform.higgsfield.ai';
 
 function json(data, status = 200) {


### PR DESCRIPTION
## Summary
Follow-up polish on the dark-theme redesign (#8), covering the requested to-do list.

## Changes
- **Interactive stars** — stronger twinkle (opacity 0.12→1 with scale), per-star drift cycles, and cursor parallax: stars shift away from the pointer scaled by a per-star `data-depth` value.
- **More hero covers** — four floating story covers on desktop (two top, two smaller bottom) with a larger float amplitude. Below 1240px the bottom pair hides and the top two remain at 30% opacity *behind* the hero text instead of disappearing.
- **Claude model → Sonnet 5** — `CLAUDE_MODEL` updated in both `server.js` and `worker/index.js`.
- **Translate guardrails** — clicking Translate with the T toggle off now shows a notice explaining how to enable it (and a second notice if no "I speak…" language is selected), on both the home and create-story pages. Uses a dark-themed SweetAlert2 modal with a plain `alert()` fallback.
- **Definition popup fix** — capped at 65vh with scrolling, and the markdown Claude returns for phrase definitions (`## headings`, `**bold**`) is now rendered as styled HTML instead of raw text.
- **Quick guide** — a "🔑 Quick guide" card on the homepage explaining the core features (read, read aloud, record, double-click definitions, T-toggle translation, create story).

## Verification
Rendered all pages in Chromium at desktop (1440px) and mobile (390px) widths with zero console errors; confirmed the translate notice fires with the correct message when the T toggle is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQ4z1UjkAX1CmARqvFi92f

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQ4z1UjkAX1CmARqvFi92f)_