### PR TITLE
More covers and stars; ElevenLabs streaming narration with emotional cues and a language voice bank

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -28,7 +28,8 @@ goes to lisa1000.com.
    Set all three production secrets:
    ```bash
    npx wrangler secret put ANTHROPIC_API_KEY   # Claude: stories, definitions, translation
-   npx wrangler secret put OPENAI_API_KEY      # text-to-speech only
+   npx wrangler secret put ELEVENLABS_API_KEY  # ElevenLabs streaming narration (Lisa & Adam voices)
+   npx wrangler secret put OPENAI_API_KEY      # story images + TTS fallback
    npx wrangler secret put HF_CREDENTIALS      # Higgsfield "KEY_ID:KEY_SECRET" for illustrations
    ```
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ LISA 1000 is an AI-aided language learning tool that uses storytelling to help u
 
 ## Features
 
-- **Text to Speech**: Via OpenAI's TTS API + Choice of voice.
+- **Streaming Text to Speech**: ElevenLabs streaming narration with cloned voices (Lisa & Adam) and emotional delivery cues; OpenAI TTS as fallback.
 - **Speech to Text Synthesis**: Webkit speech recognition to capture user narration.
 - **Claude-Powered Stories, Definitions & Translation**: Story generation, word definitions, and translation are handled by Anthropic's Claude API (Claude Opus 4.8).
 - **Higgsfield Soul Image Generation**: Generate images to accompany your stories via the Higgsfield API.
@@ -48,7 +48,8 @@ To get started with Lisa 1000, follow these steps:
       ```plaintext
       ANTHROPIC_API_KEY=your_anthropic_api_key      # Claude: stories, definitions, translation
       HF_CREDENTIALS=your_key_id:your_key_secret    # Higgsfield: image generation
-      OPENAI_API_KEY=your_openai_api_key            # OpenAI: text-to-speech only
+      ELEVENLABS_API_KEY=your_elevenlabs_api_key    # ElevenLabs: streaming narration (Lisa & Adam voices)
+      OPENAI_API_KEY=your_openai_api_key            # OpenAI: story images + TTS fallback
       ```
 
 5. **Start the server**:

--- a/myproject/public/create-story.html
+++ b/myproject/public/create-story.html
@@ -37,8 +37,13 @@
             </nav>
         </div>
         <div class="page-header">
-            <h1>Create a story</h1>
-            <p>Tell us the spark — we'll turn it into an illustrated, narrated tale.</p>
+            <div class="star-field" data-stars="22" aria-hidden="true"></div>
+            <img src="images/covers/story_1.webp" alt="" class="header-float left">
+            <img src="images/covers/story_6.webp" alt="" class="header-float right">
+            <div class="page-header-inner">
+                <h1>Create a story</h1>
+                <p>Tell us the spark — we'll turn it into an illustrated, narrated tale.</p>
+            </div>
         </div>
     </header>
     <main class="create-main">
@@ -137,12 +142,9 @@
         <div id="button-container" style="display: none;">
             <label for="voiceDropdown">Voice:</label>
             <select id="voiceDropdown">
-                <option value="nova" selected>Lisa</option>
-                <option value="alloy">Andi</option>
-                <option value="echo">Dave</option>
-                <option value="fable">Hannah</option>
-                <option value="onyx">Roy</option>
-                <option value="shimmer">Emma</option>
+                <option value="lisa" selected>Lisa</option>
+                <option value="adam">Adam</option>
+                <option value="yours" disabled>🎤 Your Voice — sign up (soon)</option>
             </select>
             <button id="readButton">🔊 Read</button>
             <button id="translateButton" class="ghost">🌍 Translate</button>
@@ -158,6 +160,8 @@
             <a href="library.html">Library</a>
         </div>
     </footer>
+    <script src="js/stars.js"></script>
+    <script src="js/tts.js"></script>
     <script src="js/createStory.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 </body>

--- a/myproject/public/css/style.css
+++ b/myproject/public/css/style.css
@@ -315,10 +315,12 @@ header { background: transparent; }
     z-index: 1;
 }
 
-.hero-float.left { --tilt: -7deg; left: 3%; top: 20%; }
-.hero-float.right { --tilt: 6deg; right: 3%; top: 30%; animation-duration: 7s; animation-delay: 1s; }
-.hero-float.bottom-left { --tilt: 5deg; left: 9%; top: 68%; width: 150px; animation-duration: 8s; animation-delay: 0.5s; }
-.hero-float.bottom-right { --tilt: -5deg; right: 9%; top: 70%; width: 150px; animation-duration: 6.5s; animation-delay: 1.6s; }
+.hero-float.left { --tilt: -7deg; left: 3%; top: 18%; }
+.hero-float.right { --tilt: 6deg; right: 3%; top: 26%; animation-duration: 7s; animation-delay: 1s; }
+.hero-float.bottom-left { --tilt: 5deg; left: 10%; top: 68%; width: 150px; animation-duration: 8s; animation-delay: 0.5s; }
+.hero-float.bottom-right { --tilt: -5deg; right: 10%; top: 70%; width: 150px; animation-duration: 6.5s; animation-delay: 1.6s; }
+.hero-float.mid-left { --tilt: 4deg; left: -24px; top: 44%; width: 120px; opacity: 0.55; animation-duration: 9s; animation-delay: 2.2s; }
+.hero-float.mid-right { --tilt: -4deg; right: -24px; top: 48%; width: 120px; opacity: 0.55; animation-duration: 8.5s; animation-delay: 0.8s; }
 
 .star-field {
     position: absolute;
@@ -337,6 +339,7 @@ header { background: transparent; }
     font-style: normal;
     display: inline-block;
     color: var(--lavender);
+    text-shadow: 0 0 6px currentColor, 0 0 16px currentColor;
     animation-name: twinkle, floaty;
     animation-iteration-count: infinite, infinite;
     animation-timing-function: ease-in-out, ease-in-out;
@@ -346,7 +349,8 @@ header { background: transparent; }
 
 /* On smaller screens keep two covers, faded behind the hero text */
 @media (max-width: 1240px) {
-    .hero-float.bottom-left, .hero-float.bottom-right { display: none; }
+    .hero-float.bottom-left, .hero-float.bottom-right,
+    .hero-float.mid-left, .hero-float.mid-right { display: none; }
 
     .hero-float.left, .hero-float.right {
         z-index: 0;
@@ -360,10 +364,14 @@ header { background: transparent; }
 
 /* ---------- Page header (Library / Create Story) ---------- */
 .page-header {
-    padding: 64px 24px 40px;
+    position: relative;
+    overflow: hidden;
+    padding: 64px 24px 46px;
     text-align: center;
     background: radial-gradient(ellipse 60% 70% at 50% -10%, rgba(109, 40, 217, 0.45), transparent 70%);
 }
+
+.page-header-inner { position: relative; z-index: 2; }
 
 .page-header h1 {
     margin: 0 0 12px;
@@ -374,6 +382,25 @@ header { background: transparent; }
     margin: 0;
     color: var(--text-muted);
     font-size: 17px;
+}
+
+.header-float {
+    position: absolute;
+    width: 150px;
+    border-radius: 12px;
+    opacity: 0.45;
+    box-shadow: 0 14px 36px rgba(0, 0, 0, 0.55), 0 0 0 1px rgba(255, 255, 255, 0.08);
+    animation: floaty-lg 7s ease-in-out infinite;
+    z-index: 1;
+}
+
+.header-float.left { --tilt: -6deg; left: 6%; top: 26%; }
+.header-float.right { --tilt: 5deg; right: 6%; top: 34%; animation-duration: 8s; animation-delay: 1.2s; }
+
+@media (max-width: 900px) {
+    .header-float { width: 110px; opacity: 0.25; }
+    .header-float.left { left: -24px; }
+    .header-float.right { right: -24px; }
 }
 
 /* ---------- Feature cards ---------- */

--- a/myproject/public/index.html
+++ b/myproject/public/index.html
@@ -38,30 +38,13 @@
         </div>
     </header>
     <section class="hero">
-        <div id="star-field" class="star-field" aria-hidden="true">
-            <span class="star" data-depth="1.2" style="top:8%; left:12%;"><i style="font-size:11px; animation-duration:2.6s,5.5s; animation-delay:0.2s,0.4s;">✦</i></span>
-            <span class="star gold" data-depth="0.6" style="top:18%; left:28%;"><i style="font-size:8px; animation-duration:3.4s,7s; animation-delay:1.1s,1.8s;">✦</i></span>
-            <span class="star" data-depth="0.9" style="top:6%; left:58%;"><i style="font-size:9px; animation-duration:2.9s,6.2s; animation-delay:2s,0.7s;">✦</i></span>
-            <span class="star" data-depth="1.4" style="top:22%; left:72%;"><i style="font-size:13px; animation-duration:2.4s,5s; animation-delay:0.6s,2.1s;">✦</i></span>
-            <span class="star gold" data-depth="0.7" style="top:44%; left:8%;"><i style="font-size:9px; animation-duration:3.8s,7.6s; animation-delay:1.6s,0.3s;">✦</i></span>
-            <span class="star" data-depth="0.5" style="top:60%; left:20%;"><i style="font-size:8px; animation-duration:3.1s,6.8s; animation-delay:2.4s,1.2s;">✦</i></span>
-            <span class="star" data-depth="1.1" style="top:38%; left:88%;"><i style="font-size:10px; animation-duration:2.7s,5.8s; animation-delay:0.9s,2.6s;">✦</i></span>
-            <span class="star gold" data-depth="1.3" style="top:66%; left:80%;"><i style="font-size:12px; animation-duration:2.5s,5.2s; animation-delay:1.9s,0.9s;">✦</i></span>
-            <span class="star" data-depth="0.8" style="top:76%; left:44%;"><i style="font-size:8px; animation-duration:3.6s,7.2s; animation-delay:0.4s,1.5s;">✦</i></span>
-            <span class="star" data-depth="0.6" style="top:12%; left:42%;"><i style="font-size:8px; animation-duration:3.3s,6.5s; animation-delay:2.8s,0.2s;">✦</i></span>
-            <span class="star gold" data-depth="1.0" style="top:52%; left:60%;"><i style="font-size:9px; animation-duration:2.8s,6s; animation-delay:1.3s,2.3s;">✦</i></span>
-            <span class="star" data-depth="1.2" style="top:80%; left:64%;"><i style="font-size:11px; animation-duration:2.6s,5.4s; animation-delay:2.2s,1s;">✦</i></span>
-            <span class="star" data-depth="0.9" style="top:30%; left:16%;"><i style="font-size:9px; animation-duration:3s,6.4s; animation-delay:0.8s,1.7s;">✦</i></span>
-            <span class="star gold" data-depth="1.5" style="top:10%; left:82%;"><i style="font-size:12px; animation-duration:2.3s,4.8s; animation-delay:1.4s,0.6s;">✦</i></span>
-            <span class="star" data-depth="0.7" style="top:70%; left:8%;"><i style="font-size:8px; animation-duration:3.5s,7.4s; animation-delay:2.6s,2s;">✦</i></span>
-            <span class="star" data-depth="1.1" style="top:86%; left:26%;"><i style="font-size:10px; animation-duration:2.9s,5.6s; animation-delay:0.5s,1.1s;">✦</i></span>
-            <span class="star gold" data-depth="0.8" style="top:34%; left:50%;"><i style="font-size:8px; animation-duration:3.2s,6.6s; animation-delay:1.8s,0.8s;">✦</i></span>
-            <span class="star" data-depth="1.3" style="top:58%; left:92%;"><i style="font-size:11px; animation-duration:2.5s,5.1s; animation-delay:2.1s,1.4s;">✦</i></span>
-        </div>
+        <div class="star-field" data-stars="42" aria-hidden="true"></div>
         <img src="images/covers/story_2.webp" alt="" class="hero-float left">
         <img src="images/covers/story_10.webp" alt="" class="hero-float right">
         <img src="images/covers/story_3.webp" alt="" class="hero-float bottom-left">
         <img src="images/covers/story_7.webp" alt="" class="hero-float bottom-right">
+        <img src="images/covers/story_5.webp" alt="" class="hero-float mid-left">
+        <img src="images/covers/story_8.webp" alt="" class="hero-float mid-right">
         <div class="hero-inner">
             <span class="hero-badge">✨ AI-powered language learning</span>
             <h1 class="hero-title">Learn a language through <span class="gradient-text">stories you'll actually love</span></h1>
@@ -81,8 +64,8 @@
         </div>
         <div class="feature-card">
             <span class="feature-icon">🎧</span>
-            <h3>Six natural voices</h3>
-            <p>Listen to any story in six natural voices — or narrate it yourself and compare your pronunciation.</p>
+            <h3>Lifelike narration</h3>
+            <p>Stories are streamed aloud in real time by expressive voices with emotional delivery — or narrate them yourself and compare your pronunciation.</p>
         </div>
         <div class="feature-card">
             <span class="feature-icon">🌍</span>
@@ -98,12 +81,9 @@
             <div class="reader-controls">
                 <label for="voiceDropdown">Voice:</label>
                 <select id="voiceDropdown">
-                    <option value="nova">Lisa</option>
-                    <option value="alloy">Andi</option>
-                    <option value="echo">Dave</option>
-                    <option value="fable">Hannah</option>
-                    <option value="onyx">Roy</option>
-                    <option value="shimmer">Emma</option>
+                    <option value="lisa">Lisa</option>
+                    <option value="adam">Adam</option>
+                    <option value="yours" disabled>🎤 Your Voice — sign up (soon)</option>
                 </select>
                 <div class="button-group">
                     <button id="readButton">🔊 Read aloud</button>
@@ -147,7 +127,7 @@
         <h3>🔑 Quick guide</h3>
         <ul>
             <li><span class="key-chip">📖 Read</span><span>Pick any story from the <a href="library.html">Library</a> — or start with the featured one above.</span></li>
-            <li><span class="key-chip">🔊 Read aloud</span><span>Choose one of six voices and listen to the story narrated.</span></li>
+            <li><span class="key-chip">🔊 Read aloud</span><span>Pick Lisa or Adam and hear the story streamed aloud instantly.</span></li>
             <li><span class="key-chip">🎙 Record</span><span>Narrate the story yourself and play back your recording.</span></li>
             <li><span class="key-chip">👆 Double-click</span><span>Double-click any word for its definition and pronunciation.</span></li>
             <li><span class="key-chip">T&nbsp;Translate</span><span>Turn on the <strong>T</strong> toggle and pick "I speak…" — then double-click words or press Translate.</span></li>
@@ -162,6 +142,8 @@
             <a href="create-story.html">Create story</a>
         </div>
     </footer>
+    <script src="js/stars.js"></script>
+    <script src="js/tts.js"></script>
     <script src="js/script.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 </body>

--- a/myproject/public/js/createStory.js
+++ b/myproject/public/js/createStory.js
@@ -92,10 +92,13 @@ document.addEventListener('DOMContentLoaded', function() {
     const fineTuneOptions = document.getElementById('fineTuneOptions');
     const storyContainer = document.getElementById('c-story-container');
     
-    let selectedVoice = 'nova'; // Default to "Lisa"
+    let selectedVoice = 'lisa'; // Default to "Lisa"
+    // Story text annotated with [emotional cues] — used for narration only,
+    // never displayed. Cleared on translation (cues belong to the original).
+    let currentNarration = null;
 
     // Ensure the default voice is set to "Lisa" in the dropdown
-    voiceDropdown.value = 'nova';
+    voiceDropdown.value = 'lisa';
 
     voiceDropdown.addEventListener('change', function() {
         selectedVoice = voiceDropdown.value;
@@ -169,10 +172,11 @@ document.addEventListener('DOMContentLoaded', function() {
         const randomLength = lengthOptions[Math.floor(Math.random() * lengthOptions.length)];
         const randomGenre = genreOptions[Math.floor(Math.random() * genreOptions.length)];
         const stopLoading = startLoading(randomStoryButton);
-        const storyData = await generateStory(`Write a ${randomLength} ${randomGenre} story suitable for language learning alongside a highly detailed relevant imagePrompt for the illustration: Your text output is: story|imagePrompt`);
+        const storyData = await generateStory(`Write a ${randomLength} ${randomGenre} story suitable for language learning alongside a narration copy with emotional delivery cues and a highly detailed relevant imagePrompt for the illustration: Your text output is: story|narration|imagePrompt`);
         stopLoading();
         if (storyData) {
             displayStory(storyData.story, storyData.imageUrl, `Generated ${randomGenre} Story`);
+            currentNarration = storyData.narration || null;
             buttonContainer.style.display = 'flex';
         } else {
             displayStory(null);
@@ -191,13 +195,14 @@ document.addEventListener('DOMContentLoaded', function() {
         const emotion = document.getElementById('emotion').value;
         const language = document.getElementById('language').value;
     
-        const prompt = `Write a ${length} story with ${characterNum} characters (participants) in the ${language} language leaving you ${emotion} in the end. Alongside a highly detailed relevant imagePrompt for the illustration: Your text output is: story|imagePrompt`;
+        const prompt = `Write a ${length} story with ${characterNum} characters (participants) in the ${language} language leaving you ${emotion} in the end. Alongside a narration copy with emotional delivery cues and a highly detailed relevant imagePrompt for the illustration: Your text output is: story|narration|imagePrompt`;
         console.log(`Generating a story with prompt: ${prompt}`); // Debugging code
         const stopLoading = startLoading(generateFineTunedStoryButton);
         const storyData = await generateStory(prompt);
         stopLoading();
         if (storyData) {
             displayStory(storyData.story, storyData.imageUrl, `Generated ${genre} Story`);
+            currentNarration = storyData.narration || null;
             buttonContainer.style.display = 'flex';
         } else {
             displayStory(null);
@@ -218,7 +223,7 @@ document.addEventListener('DOMContentLoaded', function() {
         const video = document.getElementById('video').checked;
         const subtitles = document.getElementById('subtitles').checked;
 
-        const prompt = `Title: ${title}, Theme: ${theme}, Input Language: ${inputLanguage}, Text: ${textInput}, outputLanguage: ${outputLanguage}, Music: ${music}, alongside a highly detailed relevant imagePrompt for the illustration: Your text output is: story|imagePrompt`;
+        const prompt = `Title: ${title}, Theme: ${theme}, Input Language: ${inputLanguage}, Text: ${textInput}, outputLanguage: ${outputLanguage}, Music: ${music}, alongside a narration copy with emotional delivery cues and a highly detailed relevant imagePrompt for the illustration: Your text output is: story|narration|imagePrompt`;
         console.log(`Generating a story with prompt: ${prompt}`); // Debugging code
         const submitButton = generateStoryForm.querySelector('button[type="submit"]');
         const stopLoading = startLoading(submitButton);
@@ -226,7 +231,10 @@ document.addEventListener('DOMContentLoaded', function() {
         stopLoading();
         if (storyData) {
             displayStory(storyData.story, storyData.imageUrl, title);
+            currentNarration = storyData.narration || null;
             buttonContainer.style.display = 'flex';
+            // Narrate in the language the story was generated in
+            window.currentStoryLanguage = outputLanguage;
         } else {
             displayStory(null);
         }
@@ -234,7 +242,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
     readButton.addEventListener('click', function() {
         const storyText = document.getElementById('story-content').textContent;
-        readStoryAloud(storyText, selectedVoice);
+        // Prefer the cue-annotated narration when we have one for this story
+        readStoryAloud(currentNarration || storyText, selectedVoice);
     });
     translateButton.addEventListener('click', async function() {
         const translationToggle = document.getElementById('translation-toggle').classList.contains('active');
@@ -261,6 +270,10 @@ document.addEventListener('DOMContentLoaded', function() {
                     const currentImageURL = document.querySelector('.generated-image').src;
                     const currentTitle = document.querySelector('#c-story-container h2').textContent;
                     displayStory(translatedStory, currentImageURL, currentTitle);
+                    // Narration follows the story's language from here on;
+                    // the cue-annotated copy belonged to the original language.
+                    window.currentStoryLanguage = targetLanguage;
+                    currentNarration = null;
                 }
             } finally {
                 translateButton.disabled = false;
@@ -276,28 +289,14 @@ document.addEventListener('DOMContentLoaded', function() {
 
     narrateButton.addEventListener('click', function() {
         const storyText = document.getElementById('story-content').textContent;
-        readStoryAloud(storyText, selectedVoice);
+        readStoryAloud(currentNarration || storyText, selectedVoice);
     });
 
-    // Function to read the story aloud
-    async function readStoryAloud(text, voice) {
+    // Read the story aloud — streamed from ElevenLabs, voice picked from the
+    // language bank so a translated story is narrated in its own language.
+    async function readStoryAloud(text, voiceKey) {
         try {
-            const response = await fetch('/generate-speech', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify({ text: text, voice: voice }) // Pass the voice to the server
-            });
-    
-            if (response.ok) {
-                const blob = await response.blob();
-                const url = URL.createObjectURL(blob);
-                const audio = new Audio(url);
-                audio.play();
-            } else {
-                throw new Error('Network response was not ok.');
-            }
+            await streamSpeech(text, voiceKey, window.currentStoryLanguage);
         } catch (error) {
             console.error('Error reading story aloud:', error);
         }

--- a/myproject/public/js/script.js
+++ b/myproject/public/js/script.js
@@ -85,22 +85,6 @@ function cycleText() {
 
 window.onload = cycleText;
 
-// Parallax: stars drift away from the cursor, scaled by their depth
-document.addEventListener('DOMContentLoaded', function() {
-    const starField = document.getElementById('star-field');
-    if (!starField) return;
-    const stars = starField.querySelectorAll('[data-depth]');
-    window.addEventListener('mousemove', function(e) {
-        const r = starField.getBoundingClientRect();
-        const dx = (e.clientX - (r.left + r.width / 2)) / r.width;
-        const dy = (e.clientY - (r.top + r.height / 2)) / r.height;
-        stars.forEach(star => {
-            const depth = parseFloat(star.getAttribute('data-depth'));
-            star.style.transform = `translate(${(dx * depth * -26).toFixed(1)}px, ${(dy * depth * -18).toFixed(1)}px)`;
-        });
-    });
-});
-
 // Small toast-style notice (SweetAlert2 when available, alert() otherwise)
 function notifyUser(title, text) {
     if (window.Swal) {
@@ -110,32 +94,18 @@ function notifyUser(title, text) {
     }
 }
 
-// Function to read the story aloud
-async function readStoryAloud(text, voice) {
+// Read the story aloud — streamed from ElevenLabs, voice picked from the
+// language bank so a translated story is narrated in its own language.
+async function readStoryAloud(text, voiceKey) {
     try {
-        const response = await fetch('/generate-speech', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({ text: text, voice: voice }) // Pass the voice to the server
-        });
-
-        if (response.ok) {
-            const blob = await response.blob();
-            const url = URL.createObjectURL(blob);
-            const audio = new Audio(url);
-            audio.play();
-        } else {
-            throw new Error('Network response was not ok.');
-        }
+        await streamSpeech(text, voiceKey, window.currentStoryLanguage);
     } catch (error) {
         console.error('Error reading story aloud:', error);
     }
 }
 
 
-document.getElementById('readButton').addEventListener('click', function() {
+document.getElementById('readButton').addEventListener('click', async function() {
     // Get the title and content of the story
     const title = document.getElementById('story-title').textContent;
     const content = document.getElementById('story-content').textContent;
@@ -145,9 +115,15 @@ document.getElementById('readButton').addEventListener('click', function() {
 
     // Get the selected voice
     const selectedVoice = document.getElementById('voiceDropdown').value;
-    
+
     if (selectedVoice) {
-        readStoryAloud(text, selectedVoice);
+        const btn = this;
+        btn.disabled = true;
+        try {
+            await readStoryAloud(text, selectedVoice);
+        } finally {
+            btn.disabled = false;
+        }
     } else {
         console.log('No voice selected.');
     }
@@ -321,6 +297,8 @@ async function translateStory() {
             const translatedStory = await translateText(storyText, targetLanguage);
             if (translatedStory) {
                 storyContentElement.textContent = translatedStory;  // Update only the text content
+                // Narration follows the story's language from here on
+                window.currentStoryLanguage = targetLanguage;
             }
         } finally {
             if (btn) btn.disabled = false;

--- a/myproject/public/js/stars.js
+++ b/myproject/public/js/stars.js
@@ -1,0 +1,54 @@
+// Fills every .star-field element with twinkling, drifting stars and makes
+// them parallax away from the cursor. Star count comes from data-stars
+// (default 30); positions are seeded so each page load looks the same.
+(function () {
+    function seeded(i) {
+        const x = Math.sin(i * 127.1 + 311.7) * 43758.5453;
+        return x - Math.floor(x);
+    }
+
+    function populate(field) {
+        const count = parseInt(field.getAttribute('data-stars'), 10) || 30;
+        for (let i = 0; i < count; i++) {
+            const depth = 0.4 + seeded(i + 7) * 1.2;
+            const star = document.createElement('span');
+            star.className = 'star' + (seeded(i + 3) > 0.72 ? ' gold' : '');
+            star.setAttribute('data-depth', depth.toFixed(2));
+            star.style.top = (2 + seeded(i + 1) * 90) + '%';
+            star.style.left = (1 + seeded(i + 2) * 97) + '%';
+
+            const inner = document.createElement('i');
+            inner.textContent = '✦';
+            inner.style.fontSize = (6 + depth * 7).toFixed(0) + 'px';
+            inner.style.animationDuration =
+                (2 + seeded(i + 4) * 2.5).toFixed(1) + 's, ' +
+                (4.5 + seeded(i + 5) * 4).toFixed(1) + 's';
+            inner.style.animationDelay =
+                (seeded(i + 6) * 3).toFixed(1) + 's, ' +
+                (seeded(i + 8) * 4).toFixed(1) + 's';
+
+            star.appendChild(inner);
+            field.appendChild(star);
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        const fields = document.querySelectorAll('.star-field');
+        if (!fields.length) return;
+        fields.forEach(populate);
+
+        window.addEventListener('mousemove', function (e) {
+            fields.forEach(function (field) {
+                const r = field.getBoundingClientRect();
+                if (!r.width || !r.height) return;
+                const dx = (e.clientX - (r.left + r.width / 2)) / r.width;
+                const dy = (e.clientY - (r.top + r.height / 2)) / r.height;
+                field.querySelectorAll('[data-depth]').forEach(function (star) {
+                    const d = parseFloat(star.getAttribute('data-depth'));
+                    star.style.transform =
+                        'translate(' + (dx * d * -28).toFixed(1) + 'px, ' + (dy * d * -20).toFixed(1) + 'px)';
+                });
+            });
+        });
+    });
+})();

--- a/myproject/public/js/tts.js
+++ b/myproject/public/js/tts.js
@@ -1,0 +1,82 @@
+// ElevenLabs narration: voice bank + streaming playback.
+//
+// The voice dropdowns hold voice KEYS ('lisa', 'adam'); voiceForLanguage()
+// resolves a key + story language to a concrete ElevenLabs voice_id.
+// window.currentStoryLanguage is updated after a translation so the reading
+// voice follows the story's language.
+
+// Per-language narrator bank. The default voices are multilingual, so they
+// can already read any language; add a cloned voice_id under a language code
+// to give that language its own dedicated narrator.
+const VOICE_BANK = {
+    default: {
+        lisa: 'kv1Qe4fUcVPEC2ZisX5i',
+        adam: 'IRHApOXLvnW57QJPQH2P',
+    },
+    // e.g. fr: { lisa: '<french-lisa-voice-id>', adam: '<french-adam-voice-id>' },
+    fr: {},
+    es: {},
+    de: {},
+    zh: {},
+    ar: {},
+};
+
+window.currentStoryLanguage = 'en';
+
+function voiceForLanguage(voiceKey, language) {
+    const lang = (language || 'en').toLowerCase();
+    const bank = VOICE_BANK[lang] || {};
+    return bank[voiceKey] || VOICE_BANK.default[voiceKey] || VOICE_BANK.default.lisa;
+}
+
+// Stream narration from /generate-speech and start playing as soon as the
+// first audio chunks arrive (MediaSource), falling back to whole-file
+// playback where MSE isn't supported. Resolves when playback finishes.
+async function streamSpeech(text, voiceKey, language) {
+    const lang = language || window.currentStoryLanguage || 'en';
+    const response = await fetch('/generate-speech', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: text, voice: voiceForLanguage(voiceKey, lang), language: lang }),
+    });
+    if (!response.ok) {
+        throw new Error(`Speech request failed (${response.status})`);
+    }
+
+    const mime = 'audio/mpeg';
+    const canStream = window.MediaSource && MediaSource.isTypeSupported(mime) && response.body;
+
+    if (!canStream) {
+        const blob = await response.blob();
+        const audio = new Audio(URL.createObjectURL(blob));
+        await audio.play();
+        await new Promise((resolve) => { audio.onended = resolve; audio.onerror = resolve; });
+        return;
+    }
+
+    const mediaSource = new MediaSource();
+    const audio = new Audio(URL.createObjectURL(mediaSource));
+    await new Promise((resolve) => mediaSource.addEventListener('sourceopen', resolve, { once: true }));
+    const sourceBuffer = mediaSource.addSourceBuffer(mime);
+    const reader = response.body.getReader();
+
+    const appendChunk = (chunk) => new Promise((resolve, reject) => {
+        sourceBuffer.addEventListener('updateend', resolve, { once: true });
+        sourceBuffer.addEventListener('error', reject, { once: true });
+        sourceBuffer.appendBuffer(chunk);
+    });
+
+    let started = false;
+    while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        await appendChunk(value);
+        if (!started) {
+            started = true;
+            audio.play().catch((e) => console.error('Audio playback blocked:', e));
+        }
+    }
+    if (mediaSource.readyState === 'open') mediaSource.endOfStream();
+
+    await new Promise((resolve) => { audio.onended = resolve; audio.onerror = resolve; });
+}

--- a/myproject/public/library.html
+++ b/myproject/public/library.html
@@ -37,8 +37,13 @@
             </nav>
         </div>
         <div class="page-header">
-            <h1>The Library</h1>
-            <p>Every story, beautifully illustrated — pick one and start reading.</p>
+            <div class="star-field" data-stars="22" aria-hidden="true"></div>
+            <img src="images/covers/story_4.webp" alt="" class="header-float left">
+            <img src="images/covers/story_9.webp" alt="" class="header-float right">
+            <div class="page-header-inner">
+                <h1>The Library</h1>
+                <p>Every story, beautifully illustrated — pick one and start reading.</p>
+            </div>
         </div>
     </header>
 
@@ -53,6 +58,7 @@
             <a href="create-story.html">Create story</a>
         </div>
     </footer>
+    <script src="js/stars.js"></script>
     <script src="js/loadStories.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 </body>

--- a/myproject/server.js
+++ b/myproject/server.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import cors from 'cors';
+import { Readable } from 'node:stream';
 import Anthropic from '@anthropic-ai/sdk';
 import OpenAI from 'openai';
 import { higgsfield } from '@higgsfield/client/v2';
@@ -125,7 +126,48 @@ app.post('/translate', async (req, res) => {
 });
 
 
-// Endpoint for generating speech (OpenAI TTS — Claude does not do audio)
+// ---------- Text-to-speech (ElevenLabs streaming, OpenAI fallback) ----------
+
+// Cloned narrator voices. The client normally sends a concrete voice_id;
+// these cover named keys and legacy OpenAI voice names still in the wild.
+const ELEVEN_VOICES = { lisa: 'kv1Qe4fUcVPEC2ZisX5i', adam: 'IRHApOXLvnW57QJPQH2P' };
+
+function resolveElevenVoiceId(voice) {
+    if (!voice) return ELEVEN_VOICES.lisa;
+    if (ELEVEN_VOICES[voice]) return ELEVEN_VOICES[voice];
+    if (/^[a-zA-Z0-9]{16,}$/.test(voice)) return voice; // already a voice_id
+    return ['onyx', 'echo', 'adam'].includes(voice) ? ELEVEN_VOICES.adam : ELEVEN_VOICES.lisa;
+}
+
+// Emotional delivery cues like [whispers]/[excited] need the v3 model;
+// plain text uses multilingual v2 (same voice can read any language).
+function elevenModelFor(text) {
+    return /\[[^\]\n]{2,30}\]/.test(text) ? 'eleven_v3' : 'eleven_multilingual_v2';
+}
+
+// Stream ElevenLabs audio straight through to the client so playback can
+// start before synthesis finishes. eleven_multilingual_v2 reads any language
+// with the same voice, so translated stories keep their narrator.
+async function streamElevenLabs(res, text, voice) {
+    const voiceId = resolveElevenVoiceId(voice);
+    const resp = await fetch(
+        `https://api.elevenlabs.io/v1/text-to-speech/${voiceId}/stream?output_format=mp3_44100_128`,
+        {
+            method: 'POST',
+            headers: {
+                'xi-api-key': process.env.ELEVENLABS_API_KEY,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ text, model_id: elevenModelFor(text) }),
+        }
+    );
+    if (!resp.ok) {
+        throw new Error(`ElevenLabs TTS failed (${resp.status}): ${await resp.text()}`);
+    }
+    res.writeHead(200, { 'Content-Type': 'audio/mpeg' });
+    Readable.fromWeb(resp.body).pipe(res);
+}
+
 async function generateSpeech(req, res) {
     const { text, voice } = req.body;
 
@@ -133,11 +175,24 @@ async function generateSpeech(req, res) {
         return res.status(400).send({ error: 'No text provided' });
     }
 
+    if (process.env.ELEVENLABS_API_KEY) {
+        try {
+            return await streamElevenLabs(res, text, voice);
+        } catch (error) {
+            console.error('ElevenLabs failed, falling back to OpenAI TTS:', error.message);
+            if (res.headersSent) return; // stream already started; nothing to salvage
+        }
+    }
+
     try {
+        // Fallback: OpenAI TTS (non-streaming). Strip emotional cues (OpenAI
+        // would read them out) and map voices onto the closest equivalents.
+        const plain = text.replace(/\[[^\]\n]{2,30}\]\s*/g, '');
+        const openaiVoice = ['adam', 'onyx', 'echo', ELEVEN_VOICES.adam].includes(voice) ? 'onyx' : 'nova';
         const mp3 = await openai.audio.speech.create({
             model: 'tts-1',
-            voice: voice || 'nova',
-            input: text,
+            voice: /^(alloy|echo|fable|onyx|nova|shimmer)$/.test(voice || '') ? voice : openaiVoice,
+            input: plain,
         });
 
         const buffer = Buffer.from(await mp3.arrayBuffer());
@@ -189,15 +244,21 @@ app.post('/generate-story', async (req, res) => {
         const message = await anthropic.messages.create({
             model: CLAUDE_MODEL,
             max_tokens: 8192,
-            system: 'You are a helpful assistant designed to write short stories and suitable image prompts in plain text format: story|imagePrompt. Output exactly one "|" separating the story from the image prompt, and nothing else.',
+            system: 'You are a helpful assistant designed to write short stories. Output plain text in exactly this format: story|narration|imagePrompt. '
+                + 'The story is the clean text shown to the reader. '
+                + 'The narration is the SAME story with inline emotional delivery cues in square brackets placed before the phrases they affect — e.g. [warmly], [excited], [whispers], [sighs], [laughs] — for an expressive text-to-speech narrator. '
+                + 'The imagePrompt is a highly detailed illustration prompt for the story. '
+                + 'Output exactly two "|" characters separating the three parts, and nothing else.',
             messages: [
                 { role: 'user', content: prompt }
             ]
         });
 
-        const [story = '', imagePrompt = ''] = claudeText(message)
-            .split('|')
-            .map((part) => part.trim());
+        const parts = claudeText(message).split('|').map((part) => part.trim());
+        // Expected: [story, narration, imagePrompt] — tolerate a missing narration part.
+        const story = parts[0] || '';
+        const narration = parts.length >= 3 ? parts[1] : story;
+        const imagePrompt = parts[parts.length - 1] || '';
 
         // Image via OpenAI GPT Image (returns base64 -> served as a data URL).
         // To switch back to Higgsfield Soul (needs platform.higgsfield.ai keys):
@@ -208,7 +269,7 @@ app.post('/generate-story', async (req, res) => {
             size: '1024x1024',
         });
 
-        res.json({ story, imageUrl: `data:image/png;base64,${imageResponse.data[0].b64_json}` });
+        res.json({ story, narration, imageUrl: `data:image/png;base64,${imageResponse.data[0].b64_json}` });
     } catch (error) {
         console.error('Error generating story and image:', error);
         res.status(500).send({ error: 'Failed to generate story and image' });

--- a/myproject/worker/index.js
+++ b/myproject/worker/index.js
@@ -3,9 +3,10 @@
 // don't match a file (and all POSTs) land here.
 //
 // Secrets come from `env`:
-//   ANTHROPIC_API_KEY  Claude (stories, definitions, translation)
-//   OPENAI_API_KEY     text-to-speech only
-//   HF_CREDENTIALS     Higgsfield "KEY_ID:KEY_SECRET" (story illustrations)
+//   ANTHROPIC_API_KEY    Claude (stories, definitions, translation)
+//   ELEVENLABS_API_KEY   text-to-speech (streaming narration)
+//   OPENAI_API_KEY       images + TTS fallback when ElevenLabs is unavailable
+//   HF_CREDENTIALS       Higgsfield "KEY_ID:KEY_SECRET" (story illustrations)
 
 import Anthropic from '@anthropic-ai/sdk';
 
@@ -102,18 +103,66 @@ async function handleTranslate(anthropic, body) {
     return json({ translatedText: claudeText(message) });
 }
 
-// OpenAI TTS via REST (Claude does not generate audio)
+// ---------- Text-to-speech (ElevenLabs streaming, OpenAI fallback) ----------
+
+// Cloned narrator voices. The client normally sends a concrete voice_id;
+// these cover named keys and legacy OpenAI voice names still in the wild.
+const ELEVEN_VOICES = { lisa: 'kv1Qe4fUcVPEC2ZisX5i', adam: 'IRHApOXLvnW57QJPQH2P' };
+
+function resolveElevenVoiceId(voice) {
+    if (!voice) return ELEVEN_VOICES.lisa;
+    if (ELEVEN_VOICES[voice]) return ELEVEN_VOICES[voice];
+    if (/^[a-zA-Z0-9]{16,}$/.test(voice)) return voice; // already a voice_id
+    return ['onyx', 'echo', 'adam'].includes(voice) ? ELEVEN_VOICES.adam : ELEVEN_VOICES.lisa;
+}
+
+// Emotional delivery cues like [whispers]/[excited] need the v3 model;
+// plain text uses multilingual v2 (same voice can read any language).
+function elevenModelFor(text) {
+    return /\[[^\]\n]{2,30}\]/.test(text) ? 'eleven_v3' : 'eleven_multilingual_v2';
+}
+
 async function handleSpeech(env, body) {
     const { text, voice } = body;
     if (!text) return json({ error: 'No text provided' }, 400);
 
+    // ElevenLabs first: the upstream body is passed through untouched, so the
+    // client starts playing while synthesis is still running.
+    if (env.ELEVENLABS_API_KEY) {
+        const voiceId = resolveElevenVoiceId(voice);
+        const resp = await fetch(
+            `https://api.elevenlabs.io/v1/text-to-speech/${voiceId}/stream?output_format=mp3_44100_128`,
+            {
+                method: 'POST',
+                headers: {
+                    'xi-api-key': env.ELEVENLABS_API_KEY,
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ text, model_id: elevenModelFor(text) }),
+            }
+        );
+        if (resp.ok) {
+            return new Response(resp.body, {
+                status: 200,
+                headers: { 'Content-Type': 'audio/mpeg' },
+            });
+        }
+        console.error('ElevenLabs TTS failed, falling back to OpenAI:', resp.status, await resp.text());
+    }
+
+    // Fallback: OpenAI TTS. Strip emotional cues (OpenAI would read them out)
+    // and map named/ElevenLabs voices onto the closest OpenAI equivalents.
+    const plain = text.replace(/\[[^\]\n]{2,30}\]\s*/g, '');
+    const openaiVoice = /^(alloy|echo|fable|onyx|nova|shimmer)$/.test(voice || '')
+        ? voice
+        : (['adam', ELEVEN_VOICES.adam].includes(voice) ? 'onyx' : 'nova');
     const resp = await fetch('https://api.openai.com/v1/audio/speech', {
         method: 'POST',
         headers: {
             'Authorization': `Bearer ${env.OPENAI_API_KEY}`,
             'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ model: 'tts-1', voice: voice || 'nova', input: text }),
+        body: JSON.stringify({ model: 'tts-1', voice: openaiVoice, input: plain }),
     });
 
     if (!resp.ok) {
@@ -184,6 +233,13 @@ async function generateIllustration(env, prompt) {
     return job.images[0].url;
 }
 
+const STORY_SYSTEM_PROMPT =
+    'You are a helpful assistant designed to write short stories. Output plain text in exactly this format: story|narration|imagePrompt. ' +
+    'The story is the clean text shown to the reader. ' +
+    'The narration is the SAME story with inline emotional delivery cues in square brackets placed before the phrases they affect — e.g. [warmly], [excited], [whispers], [sighs], [laughs] — for an expressive text-to-speech narrator. ' +
+    'The imagePrompt is a highly detailed illustration prompt for the story. ' +
+    'Output exactly two "|" characters separating the three parts, and nothing else.';
+
 async function handleGenerateStory(env, anthropic, body) {
     const prompt = body.prompt;
     if (!prompt) return json({ error: 'No prompt provided' }, 400);
@@ -191,16 +247,18 @@ async function handleGenerateStory(env, anthropic, body) {
     const message = await anthropic.messages.create({
         model: CLAUDE_MODEL,
         max_tokens: 8192,
-        system: 'You are a helpful assistant designed to write short stories and suitable image prompts in plain text format: story|imagePrompt. Output exactly one "|" separating the story from the image prompt, and nothing else.',
+        system: STORY_SYSTEM_PROMPT,
         messages: [{ role: 'user', content: prompt }],
     });
 
-    const [story = '', imagePrompt = ''] = claudeText(message)
-        .split('|')
-        .map((part) => part.trim());
+    const parts = claudeText(message).split('|').map((part) => part.trim());
+    // Expected: [story, narration, imagePrompt] — tolerate a missing narration part.
+    const story = parts[0] || '';
+    const narration = parts.length >= 3 ? parts[1] : story;
+    const imagePrompt = parts[parts.length - 1] || '';
 
     const imageUrl = await generateIllustrationOpenAI(env, (imagePrompt || story).substring(0, 1000));
-    return json({ story, imageUrl });
+    return json({ story, narration, imageUrl });
 }
 
 export default {


### PR DESCRIPTION
## Summary
Builds on the polish PR (#9): richer imagery, a brighter interactive starfield, and streamed ElevenLabs narration with cloned voices, emotional delivery cues, and a per-language voice bank.

> **Note:** this branch stacks on #9, so the diff shows both commits until #9 merges — after that it shrinks to just this PR's commit. Merge #9 first.

## Changes

**Visuals**
- Star fields are generated by a new shared `js/stars.js` on all three pages (42 stars in the hero, 22 in each page header) with glow halos, per-star twinkle/drift cycles, and cursor parallax.
- Six floating covers on the home hero (desktop); two faded covers remain behind the hero on smaller screens. The Library and Create Story headers get their own stars and faded covers.

**Streaming narration (ElevenLabs)**
- `/generate-speech` (Express server + Cloudflare worker) streams ElevenLabs audio straight through, and the client plays it via MediaSource as chunks arrive — narration starts before synthesis finishes. Falls back to OpenAI TTS when `ELEVENLABS_API_KEY` is unset or the call fails.
- Voice dropdowns now offer Lisa (`kv1Qe4fUcVPEC2ZisX5i`, default) and Adam (`IRHApOXLvnW57QJPQH2P`), plus a disabled "Your Voice" placeholder for the future sign-up voice-cloning feature.

**Language voice bank**
- New `js/tts.js` holds a `VOICE_BANK` keyed by language code. After translating (or generating a story in another output language), narration uses the voice registered for that language, falling back to the multilingual default voices until per-language clones are added.

**Emotional cues for the narrator**
- `/generate-story` now returns both the clean `story` (displayed) and a `narration` copy annotated with delivery cues like `[whispers]`/`[excited]` (streamed). Cue-bearing text is synthesized with `eleven_v3`; plain text uses `eleven_multilingual_v2`; the OpenAI fallback strips cues so they are never read aloud.

## Deployment note
Requires a new secret: `ELEVENLABS_API_KEY` (`.env` for the Express server, `npx wrangler secret put ELEVENLABS_API_KEY` for the worker). README and DEPLOY.md are updated.

## Verification
All three pages rendered in Chromium at 1440px and 390px with zero console errors; star counts and cover layout verified per page. The ElevenLabs paths couldn't be exercised end-to-end in the sandbox (no API key) — the OpenAI fallback path and all rendering are verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQ4z1UjkAX1CmARqvFi92f

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQ4z1UjkAX1CmARqvFi92f)_