### PR TITLE
Schema v1: design doc + D1 implementation (migrations, seed stories, works API)

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -27,6 +27,8 @@ goes to lisa1000.com.
 
    Set all three production secrets:
    ```bash
+   npx wrangler d1 create lisa1000             # once; paste database_id into wrangler.jsonc
+   npx wrangler d1 migrations apply lisa1000 --remote   # schema + seed stories (docs/SCHEMA.md)
    npx wrangler secret put ANTHROPIC_API_KEY   # Claude: stories, definitions, translation
    npx wrangler secret put ELEVENLABS_API_KEY  # ElevenLabs streaming narration (Lisa & Adam voices)
    npx wrangler secret put OPENAI_API_KEY      # story images + TTS fallback

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -1,0 +1,346 @@
+# LISA 1000 — Data Schema (v1)
+
+The agreed data structure for LISA 1000. This is the contract every feature
+builds against: the Library and its filters, Stories and Plays, voices and
+the per-language voice bank, characters, settings, narration caching, and
+the animation pipeline. **Settle data first, spend credits second.**
+
+- **Storage:** Cloudflare **D1** (SQLite) for all tables; **R2** for binaries
+  (audio renders, video clips, cover images, portraits).
+- **IDs:** text ULIDs/UUIDs unless noted. External IDs (ElevenLabs voice ids)
+  are stored as-is.
+- **System user:** a reserved user `lisa` owns all built-in content.
+  "Lisa's stories" is `owner_id = 'lisa'` — a filter, never a special code path.
+
+---
+
+## 1. Design principles
+
+1. **One model, tagged by kind.** A *Story* (narrated prose) and a *Play*
+   (cast + dialogue) are the same entity — a **work** — distinguished by
+   `works.kind`. The difference is a validation rule, not a table fork.
+   Library, animations, narrations, and the interchange JSON stay unified,
+   and "promote this story into a play" is a transformation, not a migration.
+2. **Author in one place, render in another.** The Create tab makes works.
+   The Animate tab renders them. An animation is a *render of a work*, never
+   part of it — one work can hold a cheap motion-comic render and a premium
+   cartoon render side by side.
+3. **Never synthesize the same thing twice.** Expensive outputs (TTS audio,
+   video clips) are cached as rows pointing at R2 objects, keyed by what
+   produced them (work × voice × language). Second listen is free.
+4. **Controlled vocabularies.** Emotions, genres, lengths, and animation
+   styles are enums/lookup tables so filters never fragment
+   ("happy" vs "Happy" vs "joyful").
+
+---
+
+## 2. Entities
+
+### users
+The root of ownership. (Auth ships before or alongside this schema; until
+then, everything can be built against the `lisa` system user.)
+
+```sql
+CREATE TABLE users (
+  id          TEXT PRIMARY KEY,
+  handle      TEXT UNIQUE NOT NULL,
+  email       TEXT UNIQUE,
+  created_at  INTEGER NOT NULL            -- unix epoch seconds
+);
+-- Reserved row: ('lisa', 'lisa', NULL, ...)
+```
+
+### voices
+One table covers three concepts: the voice catalogue, ownership
+(the old `Voice_Bank`), and the per-language bank.
+
+```sql
+CREATE TABLE voices (
+  voice_id           TEXT PRIMARY KEY,    -- provider's id, e.g. ElevenLabs
+  name               TEXT NOT NULL,       -- "Lisa", "Adam", "Papa's voice"
+  provider           TEXT NOT NULL DEFAULT 'elevenlabs',
+  owner_id           TEXT REFERENCES users(id),  -- NULL = built-in/system
+  language           TEXT,                -- BCP-47 ('fr'); NULL = multilingual
+  is_cloned          INTEGER NOT NULL DEFAULT 0,
+  preview_audio_url  TEXT,                -- R2: "hear this voice" sample
+  created_at         INTEGER NOT NULL
+);
+```
+
+Seed rows: Lisa `kv1Qe4fUcVPEC2ZisX5i`, Adam `IRHApOXLvnW57QJPQH2P`
+(owner NULL, language NULL — multilingual defaults).
+
+**Voice resolution (the bank):** for a requested (voice name/key, story
+language): pick `voices` where `language = :lang` and
+`owner_id IN (:user, NULL)`, preferring the user's own; else fall back to the
+multilingual default (`language IS NULL`). Multilingual models mean the
+fallback always works; per-language clones are an upgrade, not a requirement.
+
+### emotions
+```sql
+CREATE TABLE emotions (
+  name   TEXT PRIMARY KEY,                -- 'happy','sad','inspired','cozy',
+  emoji  TEXT                             -- 'scary','funny','calm','excited'
+);
+```
+
+### characters
+```sql
+CREATE TABLE characters (
+  id            TEXT PRIMARY KEY,
+  owner_id      TEXT NOT NULL REFERENCES users(id),
+  name          TEXT NOT NULL,
+  traits        TEXT,                     -- "brave, curious rhino"
+  backstory     TEXT,
+  visual_prompt TEXT,                     -- for consistent illustration
+  portrait_url  TEXT,                     -- R2
+  voice_id      TEXT REFERENCES voices(voice_id),  -- dialogue voice (plays)
+  created_at    INTEGER NOT NULL
+);
+```
+
+### settings
+Where a story takes place. Reusable across works.
+
+```sql
+CREATE TABLE settings (
+  id            TEXT PRIMARY KEY,
+  owner_id      TEXT NOT NULL REFERENCES users(id),
+  name          TEXT NOT NULL,            -- "The frozen forest"
+  description   TEXT,
+  visual_prompt TEXT,
+  image_url     TEXT,                     -- R2
+  created_at    INTEGER NOT NULL
+);
+```
+
+### works  ← the hub (Stories AND Plays)
+```sql
+CREATE TABLE works (
+  id              TEXT PRIMARY KEY,
+  owner_id        TEXT NOT NULL REFERENCES users(id),
+  kind            TEXT NOT NULL CHECK (kind IN ('story','play')),
+  title           TEXT NOT NULL,          -- ALWAYS present; Claude generates
+                                          -- one when the user doesn't supply it
+  genre           TEXT,                   -- 'adventure','mystery','fantasy',...
+  language        TEXT NOT NULL DEFAULT 'en',
+  length          TEXT CHECK (length IN ('very_short','short','medium','long')),
+  setting_id      TEXT REFERENCES settings(id),
+  source          TEXT NOT NULL CHECK (source IN ('lisa','user')),
+  cover_image_url TEXT,                   -- R2
+  created_at      INTEGER NOT NULL
+);
+
+CREATE INDEX idx_works_owner  ON works(owner_id);
+CREATE INDEX idx_works_kind   ON works(kind);
+CREATE INDEX idx_works_genre  ON works(genre);
+```
+
+```sql
+CREATE TABLE work_emotions (
+  work_id  TEXT NOT NULL REFERENCES works(id) ON DELETE CASCADE,
+  emotion  TEXT NOT NULL REFERENCES emotions(name),
+  PRIMARY KEY (work_id, emotion)
+);
+
+CREATE TABLE work_characters (
+  work_id      TEXT NOT NULL REFERENCES works(id) ON DELETE CASCADE,
+  character_id TEXT NOT NULL REFERENCES characters(id),
+  role         TEXT,                      -- 'protagonist','friend','villain'
+  PRIMARY KEY (work_id, character_id)
+);
+```
+
+**Kind rules (enforced in the app layer):**
+
+| | `kind = 'story'` | `kind = 'play'` |
+|---|---|---|
+| Cast (`work_characters`) | optional | **required, ≥ 1**, every member's character has a `voice_id` |
+| Scene body | `scenes.narration_text` required | `scene_lines` required per scene |
+| Narration | one voice streams everything | per-line synthesis by character voice; renders to cache rather than live-streaming |
+
+### scenes
+The body of a work — the single source of truth that the reader, TTS,
+illustration, subtitles, and every animation style all consume.
+
+```sql
+CREATE TABLE scenes (
+  id             TEXT PRIMARY KEY,
+  work_id        TEXT NOT NULL REFERENCES works(id) ON DELETE CASCADE,
+  idx            INTEGER NOT NULL,        -- order within the work
+  display_text   TEXT NOT NULL,           -- clean text shown to the reader
+  narration_text TEXT,                    -- same text + [emotional cues]
+  image_prompt   TEXT,
+  image_url      TEXT,                    -- R2
+  music_mood     TEXT,                    -- 'calm','adventurous','cozy',...
+  UNIQUE (work_id, idx)
+);
+```
+
+### scene_lines
+Dialogue depth inside a scene. Mandatory for plays; optional for stories.
+
+```sql
+CREATE TABLE scene_lines (
+  id           TEXT PRIMARY KEY,
+  scene_id     TEXT NOT NULL REFERENCES scenes(id) ON DELETE CASCADE,
+  idx          INTEGER NOT NULL,
+  character_id TEXT REFERENCES characters(id),  -- NULL = narrator
+  text         TEXT NOT NULL,
+  emotion      TEXT REFERENCES emotions(name),  -- delivery hint for TTS
+  direction    TEXT,                     -- stage direction: "(shivers)".
+                                         -- Radio mode: narrator reads it.
+                                         -- Cartoon mode: motion hint.
+  UNIQUE (scene_id, idx)
+);
+```
+
+### narrations  ← the credit-saver
+Cached TTS renders. A (work, voice, language) triple is synthesized **once**.
+
+```sql
+CREATE TABLE narrations (
+  id              TEXT PRIMARY KEY,
+  work_id         TEXT NOT NULL REFERENCES works(id) ON DELETE CASCADE,
+  voice_id        TEXT REFERENCES voices(voice_id), -- NULL for multi-voice play mixes
+  language        TEXT NOT NULL,
+  audio_url       TEXT NOT NULL,          -- R2 (mp3)
+  timestamps_json TEXT,                   -- ElevenLabs char/word timings:
+                                          -- drives word highlighting, subtitles,
+                                          -- and scene sync in animations
+  created_at      INTEGER NOT NULL,
+  UNIQUE (work_id, voice_id, language)
+);
+```
+
+### animations
+A render of a work — first-class, owned, and listed in the Animate tab.
+
+```sql
+CREATE TABLE animations (
+  id         TEXT PRIMARY KEY,
+  work_id    TEXT NOT NULL REFERENCES works(id) ON DELETE CASCADE,
+  owner_id   TEXT NOT NULL REFERENCES users(id),
+  style      TEXT NOT NULL CHECK (style IN ('kenburns','video','cartoon')),
+             -- kenburns: pan/zoom motion comic (either kind)
+             -- video:    image-to-video clips per scene (either kind)
+             -- cartoon:  lip-synced characters (plays only)
+  status     TEXT NOT NULL CHECK (status IN ('draft','rendering','ready','failed')),
+  video_url  TEXT,                        -- R2: final export (feeds social sharing)
+  created_at INTEGER NOT NULL
+);
+
+CREATE TABLE animation_clips (
+  id           TEXT PRIMARY KEY,
+  animation_id TEXT NOT NULL REFERENCES animations(id) ON DELETE CASCADE,
+  scene_id     TEXT NOT NULL REFERENCES scenes(id),
+  idx          INTEGER NOT NULL,
+  clip_url     TEXT,                      -- R2
+  start_ms     INTEGER,                   -- position on the narration timeline
+  end_ms       INTEGER,
+  status       TEXT NOT NULL DEFAULT 'pending',
+  UNIQUE (animation_id, idx)
+);
+```
+
+Animations **reference** the work's scenes via clips — they never copy them.
+Ten renders of one work share the same scene data.
+
+---
+
+## 3. Relationship map
+
+```
+users ─┬─ voices ◄──── characters ─┐
+       ├─ characters               ├─ work_characters ─┐
+       ├─ settings ◄───────────────┼───────────────────┤
+       ├─ works ───────────────────┘     work_emotions ┤
+       └─ animations ─ animation_clips ─┐              │
+                                        ▼              ▼
+                          scenes ◄───────────────── works ──► narrations
+                             └─ scene_lines            (work × voice × language)
+```
+
+---
+
+## 4. The interchange JSON (scene script)
+
+The canonical structure Claude outputs on generation and every consumer
+reads. Replaces the `story|narration|imagePrompt` string split. Persisting it
+= inserting the rows above.
+
+```json
+{
+  "kind": "play",
+  "title": "Roxy's Icy Adventure",
+  "genre": "adventure",
+  "language": "en",
+  "length": "short",
+  "emotions": ["happy", "cozy"],
+  "setting": { "name": "Frozen forest", "visual_prompt": "snow-laden pines, soft dusk light" },
+  "characters": [
+    { "name": "Roxy", "traits": "brave, curious rhino", "visual_prompt": "small grey rhino, red scarf" },
+    { "name": "Milo", "traits": "timid mouse", "visual_prompt": "white mouse, blue mittens" }
+  ],
+  "scenes": [
+    {
+      "display_text": "Roxy stood at the foot of the icy hill.",
+      "narration_text": "[gentle] Roxy stood at the foot of the icy hill.",
+      "image_prompt": "rhino gazing up an icy hill at dusk, storybook watercolor",
+      "music_mood": "adventurous",
+      "lines": [
+        { "speaker": "Roxy", "text": "I can do it!", "emotion": "determined", "direction": "(stamps her feet)" },
+        { "speaker": null,   "text": "And up she went.", "emotion": "calm" }
+      ]
+    }
+  ]
+}
+```
+
+For `kind: "story"`, `characters` may be empty and `lines` may be omitted —
+`narration_text` carries the whole scene.
+
+---
+
+## 5. Feature → query map
+
+| Feature | Query |
+|---|---|
+| Library: filter by genre | `works.genre = :g` |
+| Library: filter by user | `works.owner_id = :u` |
+| Library: Lisa's | `works.owner_id = 'lisa'` |
+| Library: Story / Play chip | `works.kind = :k` |
+| Library: by character | join `work_characters` on `character_id` |
+| Library: sad / happy | join `work_emotions` on `emotion` |
+| "Hear this voice" previews | `voices.preview_audio_url` |
+| Language voice bank | voice resolution rule (§2 voices) |
+| Replay without credits | `narrations` cache hit |
+| Word highlight / subtitles / scene sync | `narrations.timestamps_json` |
+| Promote story → play | Claude transform of the interchange JSON; same tables |
+| Social sharing / OG pages | `works` public page + `animations.video_url` asset |
+
+---
+
+## 6. Migration & sequencing notes
+
+1. **Existing content:** the 10 stories in `public/data/stories.json` become
+   `works` rows (`kind='story'`, `owner_id='lisa'`, one scene per story or per
+   paragraph); their covers in `public/images/covers/` move to R2 (or stay
+   static and `cover_image_url` points at the existing path initially).
+2. **Auth is the root.** `users` underpins ownership; build against the
+   `lisa` system user until sign-up ships.
+3. **Suggested build order:** D1 setup + this schema → migrate seed stories →
+   works API (replaces stories.json fetch) → Library filters → Characters tab
+   → Plays (create + radio-drama render) → Animate tab (kenburns → video →
+   cartoon) → sharing/export.
+
+## 7. Open questions (decide before building)
+
+- Public/private visibility on `works` (needed for a shared Library and OG
+  share pages): a `visibility` column — default private, `lisa` rows public?
+- Play audio mixing: stitch per-line clips server-side into one `narrations`
+  file, or play sequential clips client-side? (Server-side stitch is simpler
+  for replay + export; start there.)
+- Do generated illustrations belong per-scene from day one (they do for
+  animation), and is gpt-image-2 or Higgsfield Soul the default per-scene
+  engine given character reference support?

--- a/myproject/public/js/loadStories.js
+++ b/myproject/public/js/loadStories.js
@@ -1,53 +1,89 @@
+// Build one library card. `getFullText` is an async () => string used the
+// first time the card expands (D1-backed works fetch their scenes on demand).
+function buildStoryCard(mainElement, { title, image, excerpt, getFullText }) {
+    const card = document.createElement('div');
+    card.className = 'story-card';
+
+    // Cover image, with a lettered placeholder if the file is missing
+    const cover = document.createElement('img');
+    cover.src = image || '';
+    cover.alt = `${title} cover`;
+    cover.loading = 'lazy';
+    cover.onerror = function() {
+        const placeholder = document.createElement('div');
+        placeholder.className = 'cover-placeholder';
+        placeholder.textContent = title.charAt(0);
+        this.replaceWith(placeholder);
+    };
+    card.appendChild(cover);
+
+    const body = document.createElement('div');
+    body.className = 'card-body';
+
+    const heading = document.createElement('h2');
+    heading.textContent = title;
+
+    const shortText = excerpt.substring(0, 150) + '...';
+    const text = document.createElement('p');
+    text.textContent = shortText;
+
+    let fullText = null;
+    const button = document.createElement('button');
+    button.textContent = 'Read More';
+    button.addEventListener('click', async () => {
+        if (fullText === null) {
+            button.disabled = true;
+            try { fullText = await getFullText(); } finally { button.disabled = false; }
+        }
+        const expanded = card.classList.toggle('expanded');
+        text.textContent = expanded ? fullText : shortText;
+        button.textContent = expanded ? 'Show Less' : 'Read More';
+    });
+
+    body.appendChild(heading);
+    body.appendChild(text);
+    body.appendChild(button);
+    card.appendChild(body);
+    mainElement.appendChild(card);
+}
+
+// Works API (D1) first; stories.json as fallback for environments without
+// a database (local Express dev, static preview).
+async function loadLibrary() {
+    const mainElement = document.getElementById('story-list');
+
+    try {
+        const resp = await fetch('/api/works');
+        if (resp.ok) {
+            const { works } = await resp.json();
+            if (works && works.length) {
+                works.forEach(work => buildStoryCard(mainElement, {
+                    title: work.title,
+                    image: work.cover_image_url,
+                    excerpt: work.excerpt || '',
+                    getFullText: async () => {
+                        const full = await fetch(`/api/works/${encodeURIComponent(work.id)}`).then(r => r.json());
+                        return (full.scenes || []).map(s => s.display_text).join('\n\n');
+                    },
+                }));
+                return;
+            }
+        }
+    } catch (error) {
+        console.warn('Works API unavailable, falling back to stories.json:', error);
+    }
+
+    const stories = await fetch('data/stories.json').then(r => r.json());
+    stories.sort((a, b) => a.id - b.id).forEach(story => buildStoryCard(mainElement, {
+        title: story.title,
+        image: story.image,
+        excerpt: story.content,
+        getFullText: async () => story.content,
+    }));
+}
+
 document.addEventListener('DOMContentLoaded', function() {
-    fetch('data/stories.json')  // Adjusted path assuming 'stories.json' is in 'public/data'
-        .then(response => response.json())
-        .then(stories => {
-            const mainElement = document.getElementById('story-list');
-            stories.sort((a, b) => a.id - b.id).forEach(story => {
-                const card = document.createElement('div');
-                card.className = 'story-card';
-
-                // Cover image, with a lettered placeholder if the file is missing
-                const cover = document.createElement('img');
-                cover.src = story.image || '';
-                cover.alt = `${story.title} cover`;
-                cover.loading = 'lazy';
-                cover.onerror = function() {
-                    const placeholder = document.createElement('div');
-                    placeholder.className = 'cover-placeholder';
-                    placeholder.textContent = story.title.charAt(0);
-                    this.replaceWith(placeholder);
-                };
-                card.appendChild(cover);
-
-                const body = document.createElement('div');
-                body.className = 'card-body';
-
-                const heading = document.createElement('h2');
-                heading.textContent = story.title;
-
-                const excerpt = story.content.substring(0, 150) + '...';
-                const text = document.createElement('p');
-                text.textContent = excerpt;
-
-                const button = document.createElement('button');
-                button.textContent = 'Read More';
-                button.addEventListener('click', () => {
-                    const expanded = card.classList.toggle('expanded');
-                    text.textContent = expanded ? story.content : excerpt;
-                    button.textContent = expanded ? 'Show Less' : 'Read More';
-                });
-
-                body.appendChild(heading);
-                body.appendChild(text);
-                body.appendChild(button);
-                card.appendChild(body);
-                mainElement.appendChild(card);
-            });
-        })
-        .catch(error => {
-            console.error('Error loading the stories:', error);
-        });
+    loadLibrary().catch(error => console.error('Error loading the stories:', error));
 });
 document.addEventListener('DOMContentLoaded', function() {
     const currentPage = window.location.pathname.split('/').pop();

--- a/myproject/worker/index.js
+++ b/myproject/worker/index.js
@@ -261,6 +261,80 @@ async function handleGenerateStory(env, anthropic, body) {
     return json({ story, narration, imageUrl });
 }
 
+// ---------- Works API (D1 — schema in docs/SCHEMA.md) ----------
+
+// GET /api/works?kind=&genre=&owner=&emotion=&character=
+// Library listing with every filter from the schema's feature->query map.
+async function handleListWorks(env, url) {
+    if (!env.DB) return json({ error: 'Database not configured' }, 501);
+
+    const p = url.searchParams;
+    const where = [];
+    const binds = [];
+
+    if (p.get('kind'))  { where.push('w.kind = ?');     binds.push(p.get('kind')); }
+    if (p.get('genre')) { where.push('w.genre = ?');    binds.push(p.get('genre')); }
+    if (p.get('owner')) { where.push('w.owner_id = ?'); binds.push(p.get('owner')); }
+    if (p.get('emotion')) {
+        where.push('EXISTS (SELECT 1 FROM work_emotions we WHERE we.work_id = w.id AND we.emotion = ?)');
+        binds.push(p.get('emotion'));
+    }
+    if (p.get('character')) {
+        where.push(`EXISTS (SELECT 1 FROM work_characters wc
+                            JOIN characters c ON c.id = wc.character_id
+                            WHERE wc.work_id = w.id AND c.name = ? COLLATE NOCASE)`);
+        binds.push(p.get('character'));
+    }
+
+    const sql = `
+        SELECT w.id, w.kind, w.title, w.genre, w.language, w.length, w.owner_id,
+               w.cover_image_url, w.created_at,
+               (SELECT s.display_text FROM scenes s
+                WHERE s.work_id = w.id ORDER BY s.idx LIMIT 1) AS excerpt,
+               (SELECT GROUP_CONCAT(we.emotion) FROM work_emotions we
+                WHERE we.work_id = w.id) AS emotions
+        FROM works w
+        ${where.length ? 'WHERE ' + where.join(' AND ') : ''}
+        ORDER BY w.created_at DESC, w.id
+        LIMIT 100`;
+
+    const { results } = await env.DB.prepare(sql).bind(...binds).all();
+    return json({
+        works: results.map((r) => ({ ...r, emotions: r.emotions ? r.emotions.split(',') : [] })),
+    });
+}
+
+// GET /api/works/:id — full work: scenes (with lines), cast, emotions.
+async function handleGetWork(env, id) {
+    if (!env.DB) return json({ error: 'Database not configured' }, 501);
+
+    const work = await env.DB.prepare('SELECT * FROM works WHERE id = ?').bind(id).first();
+    if (!work) return json({ error: 'Work not found' }, 404);
+
+    const [scenes, lines, cast, emotions] = await Promise.all([
+        env.DB.prepare('SELECT * FROM scenes WHERE work_id = ? ORDER BY idx').bind(id).all(),
+        env.DB.prepare(`SELECT sl.* FROM scene_lines sl
+                        JOIN scenes s ON s.id = sl.scene_id
+                        WHERE s.work_id = ? ORDER BY s.idx, sl.idx`).bind(id).all(),
+        env.DB.prepare(`SELECT c.*, wc.role FROM work_characters wc
+                        JOIN characters c ON c.id = wc.character_id
+                        WHERE wc.work_id = ?`).bind(id).all(),
+        env.DB.prepare('SELECT emotion FROM work_emotions WHERE work_id = ?').bind(id).all(),
+    ]);
+
+    const linesByScene = {};
+    for (const line of lines.results) {
+        (linesByScene[line.scene_id] ||= []).push(line);
+    }
+
+    return json({
+        ...work,
+        emotions: emotions.results.map((e) => e.emotion),
+        characters: cast.results,
+        scenes: scenes.results.map((s) => ({ ...s, lines: linesByScene[s.id] || [] })),
+    });
+}
+
 export default {
     async fetch(request, env) {
         const url = new URL(request.url);
@@ -280,9 +354,15 @@ export default {
                 if (path === '/generate-story') return await handleGenerateStory(env, anthropic, body);
             }
 
-            if (method === 'GET' && path.startsWith('/definition/')) {
-                const word = decodeURIComponent(path.slice('/definition/'.length));
-                return await handleDefinition(anthropic, word);
+            if (method === 'GET') {
+                if (path === '/api/works') return await handleListWorks(env, url);
+                if (path.startsWith('/api/works/')) {
+                    return await handleGetWork(env, decodeURIComponent(path.slice('/api/works/'.length)));
+                }
+                if (path.startsWith('/definition/')) {
+                    const word = decodeURIComponent(path.slice('/definition/'.length));
+                    return await handleDefinition(anthropic, word);
+                }
             }
 
             return json({ error: 'Not found' }, 404);

--- a/myproject/worker/migrations/0001_schema.sql
+++ b/myproject/worker/migrations/0001_schema.sql
@@ -1,0 +1,153 @@
+-- LISA 1000 schema v1 — see docs/SCHEMA.md for the full design rationale.
+-- Apply with: npx wrangler d1 migrations apply lisa1000
+
+CREATE TABLE users (
+    id          TEXT PRIMARY KEY,
+    handle      TEXT UNIQUE NOT NULL,
+    email       TEXT UNIQUE,
+    created_at  INTEGER NOT NULL
+);
+
+CREATE TABLE voices (
+    voice_id           TEXT PRIMARY KEY,
+    name               TEXT NOT NULL,
+    provider           TEXT NOT NULL DEFAULT 'elevenlabs',
+    owner_id           TEXT REFERENCES users(id),
+    language           TEXT,
+    is_cloned          INTEGER NOT NULL DEFAULT 0,
+    preview_audio_url  TEXT,
+    created_at         INTEGER NOT NULL
+);
+
+CREATE TABLE emotions (
+    name   TEXT PRIMARY KEY,
+    emoji  TEXT
+);
+
+CREATE TABLE characters (
+    id            TEXT PRIMARY KEY,
+    owner_id      TEXT NOT NULL REFERENCES users(id),
+    name          TEXT NOT NULL,
+    traits        TEXT,
+    backstory     TEXT,
+    visual_prompt TEXT,
+    portrait_url  TEXT,
+    voice_id      TEXT REFERENCES voices(voice_id),
+    created_at    INTEGER NOT NULL
+);
+
+CREATE TABLE settings (
+    id            TEXT PRIMARY KEY,
+    owner_id      TEXT NOT NULL REFERENCES users(id),
+    name          TEXT NOT NULL,
+    description   TEXT,
+    visual_prompt TEXT,
+    image_url     TEXT,
+    created_at    INTEGER NOT NULL
+);
+
+CREATE TABLE works (
+    id              TEXT PRIMARY KEY,
+    owner_id        TEXT NOT NULL REFERENCES users(id),
+    kind            TEXT NOT NULL CHECK (kind IN ('story','play')),
+    title           TEXT NOT NULL,
+    genre           TEXT,
+    language        TEXT NOT NULL DEFAULT 'en',
+    length          TEXT CHECK (length IN ('very_short','short','medium','long')),
+    setting_id      TEXT REFERENCES settings(id),
+    source          TEXT NOT NULL CHECK (source IN ('lisa','user')),
+    cover_image_url TEXT,
+    created_at      INTEGER NOT NULL
+);
+
+CREATE INDEX idx_works_owner ON works(owner_id);
+CREATE INDEX idx_works_kind  ON works(kind);
+CREATE INDEX idx_works_genre ON works(genre);
+
+CREATE TABLE work_emotions (
+    work_id  TEXT NOT NULL REFERENCES works(id) ON DELETE CASCADE,
+    emotion  TEXT NOT NULL REFERENCES emotions(name),
+    PRIMARY KEY (work_id, emotion)
+);
+
+CREATE TABLE work_characters (
+    work_id      TEXT NOT NULL REFERENCES works(id) ON DELETE CASCADE,
+    character_id TEXT NOT NULL REFERENCES characters(id),
+    role         TEXT,
+    PRIMARY KEY (work_id, character_id)
+);
+
+CREATE TABLE scenes (
+    id             TEXT PRIMARY KEY,
+    work_id        TEXT NOT NULL REFERENCES works(id) ON DELETE CASCADE,
+    idx            INTEGER NOT NULL,
+    display_text   TEXT NOT NULL,
+    narration_text TEXT,
+    image_prompt   TEXT,
+    image_url      TEXT,
+    music_mood     TEXT,
+    UNIQUE (work_id, idx)
+);
+
+CREATE TABLE scene_lines (
+    id           TEXT PRIMARY KEY,
+    scene_id     TEXT NOT NULL REFERENCES scenes(id) ON DELETE CASCADE,
+    idx          INTEGER NOT NULL,
+    character_id TEXT REFERENCES characters(id),
+    text         TEXT NOT NULL,
+    emotion      TEXT REFERENCES emotions(name),
+    direction    TEXT,
+    UNIQUE (scene_id, idx)
+);
+
+CREATE TABLE narrations (
+    id              TEXT PRIMARY KEY,
+    work_id         TEXT NOT NULL REFERENCES works(id) ON DELETE CASCADE,
+    voice_id        TEXT REFERENCES voices(voice_id),
+    language        TEXT NOT NULL,
+    audio_url       TEXT NOT NULL,
+    timestamps_json TEXT,
+    created_at      INTEGER NOT NULL,
+    UNIQUE (work_id, voice_id, language)
+);
+
+CREATE TABLE animations (
+    id         TEXT PRIMARY KEY,
+    work_id    TEXT NOT NULL REFERENCES works(id) ON DELETE CASCADE,
+    owner_id   TEXT NOT NULL REFERENCES users(id),
+    style      TEXT NOT NULL CHECK (style IN ('kenburns','video','cartoon')),
+    status     TEXT NOT NULL CHECK (status IN ('draft','rendering','ready','failed')),
+    video_url  TEXT,
+    created_at INTEGER NOT NULL
+);
+
+CREATE TABLE animation_clips (
+    id           TEXT PRIMARY KEY,
+    animation_id TEXT NOT NULL REFERENCES animations(id) ON DELETE CASCADE,
+    scene_id     TEXT NOT NULL REFERENCES scenes(id),
+    idx          INTEGER NOT NULL,
+    clip_url     TEXT,
+    start_ms     INTEGER,
+    end_ms       INTEGER,
+    status       TEXT NOT NULL DEFAULT 'pending',
+    UNIQUE (animation_id, idx)
+);
+
+-- ---------- Vocabulary + system seeds ----------
+
+INSERT INTO users (id, handle, email, created_at) VALUES
+    ('lisa', 'lisa', NULL, 1752624000);
+
+INSERT INTO emotions (name, emoji) VALUES
+    ('happy',    '😊'),
+    ('sad',      '😢'),
+    ('inspired', '🌟'),
+    ('cozy',     '🕯️'),
+    ('scary',    '👻'),
+    ('funny',    '😄'),
+    ('calm',     '🌙'),
+    ('excited',  '⚡');
+
+INSERT INTO voices (voice_id, name, provider, owner_id, language, is_cloned, preview_audio_url, created_at) VALUES
+    ('kv1Qe4fUcVPEC2ZisX5i', 'Lisa', 'elevenlabs', NULL, NULL, 1, NULL, 1752624000),
+    ('IRHApOXLvnW57QJPQH2P', 'Adam', 'elevenlabs', NULL, NULL, 1, NULL, 1752624000);

--- a/myproject/worker/migrations/0002_seed_stories.sql
+++ b/myproject/worker/migrations/0002_seed_stories.sql
@@ -1,0 +1,110 @@
+-- Seed: the original 10 LISA stories from public/data/stories.json,
+-- migrated into works/scenes and owned by the system user 'lisa'.
+-- Cover images stay on the static path until assets move to R2.
+
+INSERT INTO works (id, owner_id, kind, title, genre, language, length, source, cover_image_url, created_at) VALUES
+    ('w_001', 'lisa', 'story', 'Spot', 'friendship', 'en', 'very_short', 'lisa', 'images/covers/story_1.webp', 1752624000);
+INSERT INTO work_emotions (work_id, emotion) VALUES ('w_001', 'happy');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_001_00', 'w_001', 0, 'Spot. Spot saw the shiny car and said, "Wow, Kitty, your car is so bright and clean!" Kitty smiled and replied, "Thank you, Spot. I polish it every day."');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_001_01', 'w_001', 1, 'After playing with the car, Kitty and Spot felt thirsty. They found a small pond with clear water. They drank the water and felt very happy. They played together all day and became best friends.');
+
+INSERT INTO works (id, owner_id, kind, title, genre, language, length, source, cover_image_url, created_at) VALUES
+    ('w_002', 'lisa', 'story', 'Roxy''s Icy Adventure', 'adventure', 'en', 'short', 'lisa', 'images/covers/story_2.webp', 1752624000);
+INSERT INTO work_emotions (work_id, emotion) VALUES ('w_002', 'excited');
+INSERT INTO work_emotions (work_id, emotion) VALUES ('w_002', 'cozy');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_002_00', 'w_002', 0, 'Once upon a time, in a big forest, there lived a rhinoceros named Roxy. Roxy loved to climb. She climbed trees, rocks, and hills. One day, Roxy found an icy hill. She had never seen anything like it before. It was shiny and cold, and she wanted to climb it.');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_002_01', 'w_002', 1, 'Roxy tried to climb the icy hill, but it was very slippery. She tried again and again, but she kept falling down. Roxy was sad. She wanted to climb the icy hill so much. Then, she saw a little bird named Billy. Billy saw that Roxy was sad and asked, "Why are you sad, Roxy?"');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_002_02', 'w_002', 2, 'Roxy told Billy about the icy hill and how she couldn''t climb it. Billy said, "I have an idea! Let''s find some big leaves to put under your feet. They will help you climb the icy hill." Roxy and Billy looked for big leaves and found some. Roxy put the leaves under her feet and tried to climb the icy hill again.');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_002_03', 'w_002', 3, 'This time, Roxy didn''t slip. She climbed and climbed until she reached the top of the icy hill. Roxy was so happy! She and Billy played on the icy hill all day. From that day on, Roxy and Billy were the best of friends, and they climbed and played together all the time. And Roxy learned that with a little help from a friend, she could climb anything.');
+
+INSERT INTO works (id, owner_id, kind, title, genre, language, length, source, cover_image_url, created_at) VALUES
+    ('w_003', 'lisa', 'story', 'Daisy and Max', 'friendship', 'en', 'very_short', 'lisa', 'images/covers/story_3.webp', 1752624000);
+INSERT INTO work_emotions (work_id, emotion) VALUES ('w_003', 'happy');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_003_00', 'w_003', 0, 'Once upon a time, in a small yard, there was a small daisy. The daisy had a name. Her name was Daisy. Daisy was very small, but she was also very happy.');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_003_01', 'w_003', 1, 'One day, Daisy saw a dog. The dog was big and had a name too. His name was Max. Max liked to play in the yard. Daisy liked to watch Max play. Max and Daisy became friends.');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_003_02', 'w_003', 2, 'Every day, Max would come to the yard to play. Daisy would watch and smile. They were very happy together. And even though Daisy was small, she knew that she had a big friend in Max.');
+
+INSERT INTO works (id, owner_id, kind, title, genre, language, length, source, cover_image_url, created_at) VALUES
+    ('w_004', 'lisa', 'story', 'Sue''s Thoughtful Act', 'kindness', 'en', 'short', 'lisa', 'images/covers/story_4.webp', 1752624000);
+INSERT INTO work_emotions (work_id, emotion) VALUES ('w_004', 'inspired');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_004_00', 'w_004', 0, 'Once upon a time, there was a thoughtful girl named Sue. Sue loved to help her mom around the house. One day, her mom asked her to wipe the table after they ate their lunch. Sue was happy to help.');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_004_01', 'w_004', 1, 'As Sue was wiping the table, she saw a pretty candle on the window sill. The candle was her mom''s favorite. Sue wanted to do something nice for her mom, so she said, "Mom, can I light the candle for you?" Her mom said, "Yes, but be very careful."');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_004_02', 'w_004', 2, 'Sue carefully lit the candle and put it on the table. Her mom was so happy to see the pretty candle. They both sat and watched the candle burn. Sue''s mom said, "Thank you, Sue, for being so thoughtful and careful." Sue felt proud that she could help her mom.');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_004_03', 'w_004', 3, 'The moral of the story is to always be thoughtful and careful when helping others.');
+
+INSERT INTO works (id, owner_id, kind, title, genre, language, length, source, cover_image_url, created_at) VALUES
+    ('w_005', 'lisa', 'story', 'The Kind Farmer', 'kindness', 'en', 'very_short', 'lisa', 'images/covers/story_5.webp', 1752624000);
+INSERT INTO work_emotions (work_id, emotion) VALUES ('w_005', 'inspired');
+INSERT INTO work_emotions (work_id, emotion) VALUES ('w_005', 'happy');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_005_00', 'w_005', 0, 'Once upon a time, there was a kind farmer. He had a big cow. The cow was sad. The farmer did not know why.');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_005_01', 'w_005', 1, 'One day, a little boy came to the farm. He saw the sad cow. The boy kneeled down to talk to the cow. "Why are you sad, cow?" he asked. The cow said, "I am lonely. I want a friend."');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_005_02', 'w_005', 2, 'The kind farmer heard the cow. He wanted to help. So, he got another cow to be friends with the sad cow. The sad cow was happy now. They played together every day. And the kind farmer, the little boy, and the two cows all lived happily ever after.');
+
+INSERT INTO works (id, owner_id, kind, title, genre, language, length, source, cover_image_url, created_at) VALUES
+    ('w_006', 'lisa', 'story', 'Lucy and Tom''s Park Adventure', 'adventure', 'en', 'short', 'lisa', 'images/covers/story_6.webp', 1752624000);
+INSERT INTO work_emotions (work_id, emotion) VALUES ('w_006', 'happy');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_006_00', 'w_006', 0, 'Once upon a time, there was a little girl named Lucy. She had a pet cat named Tom. They loved to play together in the big green park near their house. One sunny day, they went to the park to play.');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_006_01', 'w_006', 1, 'While playing, Tom saw a big sour lemon on the ground. He wanted to play with it, but when he touched it, it started to roll away. Tom ran after the lemon, trying to catch it. But as he ran, Tom got lost in the park. Lucy looked around, but she could not find Tom. She was very sad.');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_006_02', 'w_006', 2, 'Lucy did not give up. She searched the park for her friend. At last, she found him near a big tree. Tom was trying to catch the lemon, but it vanished into a hole in the ground. Tom was happy to see Lucy again. They hugged and went back home together. They had a fun escape in the park, but they decided to leave the sour lemon behind.');
+
+INSERT INTO works (id, owner_id, kind, title, genre, language, length, source, cover_image_url, created_at) VALUES
+    ('w_007', 'lisa', 'story', 'Spot and Buddy''s Goal', 'friendship', 'en', 'very_short', 'lisa', 'images/covers/story_7.webp', 1752624000);
+INSERT INTO work_emotions (work_id, emotion) VALUES ('w_007', 'happy');
+INSERT INTO work_emotions (work_id, emotion) VALUES ('w_007', 'funny');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_007_00', 'w_007', 0, 'Once upon a time, there was a little brown dog named Spot. He loved to play with his ball in the park. One sunny day, Spot saw a big goal on the other side of the park. He wanted to get his ball into the goal.');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_007_01', 'w_007', 1, 'Spot ran fast with the ball in his mouth. He tried to kick the ball into the goal, but he was too small. Spot started to struggle. He tried again and again, but the ball would not go in.');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_007_02', 'w_007', 2, 'Then, Spot had an idea. He asked his friend, a big brown horse named Buddy, for help. Buddy kicked the ball with his strong legs. The ball flew into the goal! Spot was so happy. He and Buddy played together all day long.');
+
+INSERT INTO works (id, owner_id, kind, title, genre, language, length, source, cover_image_url, created_at) VALUES
+    ('w_008', 'lisa', 'story', 'Tom''s Lost Ball', 'mystery', 'en', 'very_short', 'lisa', 'images/covers/story_8.webp', 1752624000);
+INSERT INTO work_emotions (work_id, emotion) VALUES ('w_008', 'happy');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_008_00', 'w_008', 0, 'Once upon a time, there was a little boy named Tom. He loved to play with his red ball. One sunny day, Tom went outside to play with his ball in the land near his home.');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_008_01', 'w_008', 1, 'Tom kicked the ball high in the sky. The ball went far, far away. Tom was sad because he could not find his ball. He walked and walked, looking for it. The land was big and sometimes dangerous. Tom knew he had to be careful.');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_008_02', 'w_008', 2, 'At last, Tom found his ball near a big tree. He was very happy. Tom knew he should not kick the ball too hard next time. He went back home, holding his ball tightly. Tom played safely in his yard, away from the dangerous land.');
+
+INSERT INTO works (id, owner_id, kind, title, genre, language, length, source, cover_image_url, created_at) VALUES
+    ('w_009', 'lisa', 'story', 'Max and the Cat', 'friendship', 'en', 'very_short', 'lisa', 'images/covers/story_9.webp', 1752624000);
+INSERT INTO work_emotions (work_id, emotion) VALUES ('w_009', 'happy');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_009_00', 'w_009', 0, 'Once upon a time, there was a big dog named Max. Max had a red collar that he wore every day. He loved to play and run in the park with his friends.');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_009_01', 'w_009', 1, 'One day, Max saw a cat on a tree. He wanted to be friends with the cat. So, Max tried to stretch up to reach the cat. But he was not tall enough. He tried again and again, but he just couldn''t reach the cat.');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_009_02', 'w_009', 2, 'Max felt sad, but then he had an idea. He found a big box and put it under the tree. Max climbed on the box and stretched one more time. This time, he reached the cat! The cat and Max became good friends, and they played together every day.');
+
+INSERT INTO works (id, owner_id, kind, title, genre, language, length, source, cover_image_url, created_at) VALUES
+    ('w_010', 'lisa', 'story', 'Mia and Tom''s Jewelry Adventure', 'adventure', 'en', 'short', 'lisa', 'images/covers/story_10.webp', 1752624000);
+INSERT INTO work_emotions (work_id, emotion) VALUES ('w_010', 'happy');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_010_00', 'w_010', 0, 'Once upon a time, there was a girl named Mia. Mia loved her jewelry. She had a big box full of pretty things. She liked to wear them all day. But at night, she had to sleep.');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_010_01', 'w_010', 1, 'One day, Mia met a talking cat named Tom. Tom was a tough cat, but he was nice. Tom said, "Hi, Mia! I like your jewelry. Can I wear some too?" Mia said, "Yes, Tom. You can wear my jewelry, but we have to give it back before we sleep."');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_010_02', 'w_010', 2, 'So, Mia and Tom played together. They wore the jewelry and had fun. They pretended to be kings and queens. They laughed and danced. But soon, the sun went down, and it was time for bed.');
+INSERT INTO scenes (id, work_id, idx, display_text) VALUES
+    ('sc_010_03', 'w_010', 3, 'Mia said, "Tom, we must give back the jewelry now. It''s time to sleep." Tom gave back the jewelry and said, "Thank you, Mia. I had fun today." They put the jewelry back in the box and went to sleep. Mia and Tom were happy, and they had sweet dreams.');

--- a/myproject/wrangler.jsonc
+++ b/myproject/wrangler.jsonc
@@ -11,5 +11,17 @@
     "compatibility_flags": ["nodejs_compat"],
     "assets": {
         "directory": "./public"
-    }
+    },
+    // D1 database (schema: docs/SCHEMA.md, migrations: worker/migrations/).
+    // One-time setup:
+    //   npx wrangler d1 create lisa1000        -> paste the database_id below
+    //   npx wrangler d1 migrations apply lisa1000 --remote
+    "d1_databases": [
+        {
+            "binding": "DB",
+            "database_name": "lisa1000",
+            "database_id": "REPLACE_WITH_DATABASE_ID",
+            "migrations_dir": "worker/migrations"
+        }
+    ]
 }

--- a/myproject/wrangler.jsonc
+++ b/myproject/wrangler.jsonc
@@ -20,7 +20,7 @@
         {
             "binding": "DB",
             "database_name": "lisa1000",
-            "database_id": "REPLACE_WITH_DATABASE_ID",
+            "database_id": "d6abaac2-b196-4dd6-abab-44ef01b58e5d",
             "migrations_dir": "worker/migrations"
         }
     ]


### PR DESCRIPTION
## Summary
The finalized v1 data model (`docs/SCHEMA.md`) **and its implementation**: Cloudflare D1 migrations, the original 10 stories migrated as seed data, and a read API powering the Library.

## The doc (`docs/SCHEMA.md`)
- **`works` hub tagged `kind = story | play`** — Stories and Plays share one table/pipeline; the difference is a validation rule. Story→play promotion is a transformation, not a migration.
- **`voices`** — catalogue + ownership (Voice_Bank) + per-language bank with multilingual fallback, in one table.
- **`scenes` + `scene_lines`** — single source of truth for reader, TTS, illustrations, subtitles, animation; stage directions double as motion hints.
- **`narrations`** — TTS cached per (work × voice × language), synthesized once.
- **`animations` + `animation_clips`** — renders of a work, decoupled from authoring.
- Interchange JSON spec, feature→query map, migration notes, open questions.

## The implementation
- **`worker/migrations/0001_schema.sql`** — full DDL + vocabulary seeds (the `lisa` system user, 8 emotions, Lisa `kv1Qe4fUcVPEC2ZisX5i` & Adam `IRHApOXLvnW57QJPQH2P` voices).
- **`worker/migrations/0002_seed_stories.sql`** — the 10 existing stories from `stories.json` as `works` rows (`kind='story'`, `owner='lisa'`, genre + emotion tags), one scene per paragraph → 10 works, 32 scenes.
- **`wrangler.jsonc`** — D1 binding (`DB`) with setup comments; `DEPLOY.md` documents the one-time `wrangler d1 create` + `migrations apply` steps.
- **`worker/index.js`** — `GET /api/works` with `kind` / `genre` / `owner` / `emotion` / `character` filters (the Library filter map from the doc) and `GET /api/works/:id` returning scenes with lines, cast, and emotions. Returns 501 when no DB is bound.
- **`loadStories.js`** — Library loads from `/api/works` first, falling back to `data/stories.json` where no database exists (local Express dev, static preview). Full story text is fetched on first expand.

## Deployment (one-time)
```
npx wrangler d1 create lisa1000        # paste database_id into wrangler.jsonc
npx wrangler d1 migrations apply lisa1000 --remote
```

## Verification
- Both migrations applied cleanly against real SQLite; filter queries return expected counts (10 works, 32 scenes, 8 happy, 3 adventure, 10 owned by `lisa`).
- Library page verified in Chromium via the fallback path: 10 cards render, expand/collapse works, zero console errors.
- `worker/index.js` and `loadStories.js` pass syntax checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQ4z1UjkAX1CmARqvFi92f