### PR TITLE
Write path: save generated stories to the library (POST /api/works)

### DIFF
--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -127,13 +127,20 @@ CREATE TABLE works (
   length          TEXT CHECK (length IN ('very_short','short','medium','long')),
   setting_id      TEXT REFERENCES settings(id),
   source          TEXT NOT NULL CHECK (source IN ('lisa','user')),
+  visibility      TEXT NOT NULL DEFAULT 'private'
+                  CHECK (visibility IN ('private','unlisted','public')),
+                  -- private:  owner only (the default — a user's story is
+                  --           theirs unless they choose otherwise)
+                  -- unlisted: reachable by direct link/share page, never listed
+                  -- public:   shown in the shared Library
   cover_image_url TEXT,                   -- R2
   created_at      INTEGER NOT NULL
 );
 
-CREATE INDEX idx_works_owner  ON works(owner_id);
-CREATE INDEX idx_works_kind   ON works(kind);
-CREATE INDEX idx_works_genre  ON works(genre);
+CREATE INDEX idx_works_owner      ON works(owner_id);
+CREATE INDEX idx_works_kind       ON works(kind);
+CREATE INDEX idx_works_genre      ON works(genre);
+CREATE INDEX idx_works_visibility ON works(visibility);
 ```
 
 ```sql
@@ -336,8 +343,11 @@ For `kind: "story"`, `characters` may be empty and `lines` may be omitted —
 
 ## 7. Open questions (decide before building)
 
-- Public/private visibility on `works` (needed for a shared Library and OG
-  share pages): a `visibility` column — default private, `lisa` rows public?
+- ~~Public/private visibility on `works`~~ **Resolved** (migration 0003):
+  `works.visibility` — `private` (default) / `unlisted` / `public`; `lisa`
+  seeds are public. Listings return only `public` (later: `OR owner = viewer`);
+  direct fetch serves `public` + `unlisted`; `private` never leaves the DB.
+  Renders (narrations, animations) inherit the work's visibility.
 - Play audio mixing: stitch per-line clips server-side into one `narrations`
   file, or play sequential clips client-side? (Server-side stitch is simpler
   for replay + export; start there.)

--- a/myproject/public/create-story.html
+++ b/myproject/public/create-story.html
@@ -149,6 +149,7 @@
             <button id="readButton">🔊 Read</button>
             <button id="translateButton" class="ghost">🌍 Translate</button>
             <button id="narrateButton" class="ghost">🎙 Narrate</button>
+            <button id="saveButton" class="ghost">💾 Save to Library</button>
             <button id="animateButton" class="coming-soon" disabled title="Animation is coming soon">Animate ✨</button>
         </div>
     </main>

--- a/myproject/public/js/createStory.js
+++ b/myproject/public/js/createStory.js
@@ -96,6 +96,8 @@ document.addEventListener('DOMContentLoaded', function() {
     // Story text annotated with [emotional cues] — used for narration only,
     // never displayed. Cleared on translation (cues belong to the original).
     let currentNarration = null;
+    // Everything needed to persist the on-screen story via POST /api/works.
+    let currentStory = null;
 
     // Ensure the default voice is set to "Lisa" in the dropdown
     voiceDropdown.value = 'lisa';
@@ -103,6 +105,91 @@ document.addEventListener('DOMContentLoaded', function() {
     voiceDropdown.addEventListener('change', function() {
         selectedVoice = voiceDropdown.value;
         console.log(`Selected voice: ${selectedVoice}`);
+    });
+
+    function setCurrentStory(title, genre, language, storyData) {
+        currentStory = {
+            title: title,
+            genre: genre || null,
+            language: language || 'en',
+            story: storyData.story,
+            narration: storyData.narration || null,
+            imageUrl: storyData.imageUrl || null,
+        };
+        const saveButton = document.getElementById('saveButton');
+        saveButton.disabled = false;
+        saveButton.textContent = '💾 Save to Library';
+    }
+
+    // Split a story into paragraph scenes; pair narration paragraphs with
+    // them when the counts line up, otherwise keep all cues on scene 0.
+    function storyToScenes(story, narration) {
+        const paras = story.split(/\n+/).map((p) => p.trim()).filter(Boolean);
+        const narrParas = narration
+            ? narration.split(/\n+/).map((p) => p.trim()).filter(Boolean)
+            : [];
+        const aligned = narrParas.length === paras.length;
+        return paras.map((p, i) => ({
+            display_text: p,
+            narration_text: aligned ? narrParas[i] : (i === 0 ? narration : null),
+        }));
+    }
+
+    document.getElementById('saveButton').addEventListener('click', async function() {
+        if (!currentStory) return;
+        const saveButton = this;
+
+        let visibility = 'public';
+        if (window.Swal) {
+            const choice = await Swal.fire({
+                title: 'Save to Library',
+                text: 'Who should see this story?',
+                input: 'radio',
+                inputOptions: { public: '🌍 Everyone', unlisted: '🔗 Only people with the link' },
+                inputValue: 'public',
+                showCancelButton: true,
+                confirmButtonText: 'Save',
+                confirmButtonColor: '#8B5CF6',
+            });
+            if (!choice.isConfirmed) return;
+            visibility = choice.value || 'public';
+        } else if (!confirm('Save this story to the public library?')) {
+            return;
+        }
+
+        saveButton.disabled = true;
+        saveButton.textContent = 'Saving...';
+        try {
+            const resp = await fetch('/api/works', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    kind: 'story',
+                    title: currentStory.title,
+                    genre: currentStory.genre,
+                    language: currentStory.language,
+                    visibility: visibility,
+                    scenes: storyToScenes(currentStory.story, currentStory.narration),
+                    cover_image_url: currentStory.imageUrl,
+                }),
+            });
+            if (!resp.ok) {
+                const detail = await resp.json().catch(() => ({}));
+                throw new Error(detail.error || `Save failed (${resp.status})`);
+            }
+            saveButton.textContent = '✓ Saved';
+            notifyUser(
+                'Saved to Library',
+                visibility === 'public'
+                    ? 'Your story is now in the Library for everyone to read.'
+                    : 'Saved! Only people with the link can view it (share pages coming soon).'
+            );
+        } catch (error) {
+            console.error('Error saving story:', error);
+            saveButton.disabled = false;
+            saveButton.textContent = '💾 Save to Library';
+            notifyUser('Could not save', String(error.message || error));
+        }
     });
 
     // Show a staged loading indicator while the story + image generate (~20-60s)
@@ -177,6 +264,7 @@ document.addEventListener('DOMContentLoaded', function() {
         if (storyData) {
             displayStory(storyData.story, storyData.imageUrl, `Generated ${randomGenre} Story`);
             currentNarration = storyData.narration || null;
+            setCurrentStory(`Generated ${randomGenre} Story`, randomGenre, 'en', storyData);
             buttonContainer.style.display = 'flex';
         } else {
             displayStory(null);
@@ -203,6 +291,7 @@ document.addEventListener('DOMContentLoaded', function() {
         if (storyData) {
             displayStory(storyData.story, storyData.imageUrl, `Generated ${genre} Story`);
             currentNarration = storyData.narration || null;
+            setCurrentStory(`Generated ${genre} Story`, genre, 'en', storyData);
             buttonContainer.style.display = 'flex';
         } else {
             displayStory(null);
@@ -232,6 +321,7 @@ document.addEventListener('DOMContentLoaded', function() {
         if (storyData) {
             displayStory(storyData.story, storyData.imageUrl, title);
             currentNarration = storyData.narration || null;
+            setCurrentStory(title, theme, outputLanguage, storyData);
             buttonContainer.style.display = 'flex';
             // Narrate in the language the story was generated in
             window.currentStoryLanguage = outputLanguage;
@@ -274,6 +364,11 @@ document.addEventListener('DOMContentLoaded', function() {
                     // the cue-annotated copy belonged to the original language.
                     window.currentStoryLanguage = targetLanguage;
                     currentNarration = null;
+                    if (currentStory) {
+                        currentStory.story = translatedStory;
+                        currentStory.narration = null;
+                        currentStory.language = targetLanguage;
+                    }
                 }
             } finally {
                 translateButton.disabled = false;

--- a/myproject/worker/index.js
+++ b/myproject/worker/index.js
@@ -269,7 +269,10 @@ async function handleListWorks(env, url) {
     if (!env.DB) return json({ error: 'Database not configured' }, 501);
 
     const p = url.searchParams;
-    const where = [];
+    // Listings only ever show public works. Once auth ships this becomes
+    // (visibility = 'public' OR owner_id = :viewer); 'unlisted' works are
+    // reachable by direct id but never listed; 'private' never leaves the DB.
+    const where = ["w.visibility = 'public'"];
     const binds = [];
 
     if (p.get('kind'))  { where.push('w.kind = ?');     binds.push(p.get('kind')); }
@@ -308,7 +311,11 @@ async function handleListWorks(env, url) {
 async function handleGetWork(env, id) {
     if (!env.DB) return json({ error: 'Database not configured' }, 501);
 
-    const work = await env.DB.prepare('SELECT * FROM works WHERE id = ?').bind(id).first();
+    // Direct fetch serves public AND unlisted (share links); private works are
+    // indistinguishable from missing ones until auth can prove ownership.
+    const work = await env.DB.prepare(
+        "SELECT * FROM works WHERE id = ? AND visibility IN ('public','unlisted')"
+    ).bind(id).first();
     if (!work) return json({ error: 'Work not found' }, 404);
 
     const [scenes, lines, cast, emotions] = await Promise.all([

--- a/myproject/worker/index.js
+++ b/myproject/worker/index.js
@@ -342,6 +342,93 @@ async function handleGetWork(env, id) {
     });
 }
 
+// POST /api/works — persist a generated story into the library.
+// Pre-auth, works are owned by the 'guest' system user; the client offers
+// 'public' or 'unlisted'. 'private' arrives with accounts (a private guest
+// work would be orphaned — nobody could ever retrieve it).
+async function handleCreateWork(env, body) {
+    if (!env.DB) return json({ error: 'Database not configured' }, 501);
+
+    const {
+        kind = 'story',
+        title,
+        genre = null,
+        language = 'en',
+        length = null,
+        visibility = 'public',
+        emotions = [],
+        scenes = [],
+        cover_image_url = null,
+    } = body || {};
+
+    if (kind !== 'story') return json({ error: "Only kind 'story' can be saved for now" }, 400);
+    if (typeof title !== 'string' || !title.trim()) return json({ error: 'A title is required' }, 400);
+    if (!['public', 'unlisted'].includes(visibility)) {
+        return json({ error: "visibility must be 'public' or 'unlisted' (private works arrive with accounts)" }, 400);
+    }
+    if (!Array.isArray(scenes) || scenes.length === 0) return json({ error: 'At least one scene is required' }, 400);
+    if (scenes.length > 50) return json({ error: 'Too many scenes (max 50)' }, 400);
+    for (const s of scenes) {
+        if (!s || typeof s.display_text !== 'string' || !s.display_text.trim()) {
+            return json({ error: 'Every scene needs display_text' }, 400);
+        }
+        if (s.display_text.length > 10000 || (s.narration_text || '').length > 12000) {
+            return json({ error: 'Scene text too long' }, 400);
+        }
+    }
+
+    // Only persist real URLs / static paths. Generated covers arrive as
+    // multi-MB base64 data URLs — storing those in D1 rows is the expensive
+    // mistake; they get an R2 upload in a follow-up and a placeholder for now.
+    const keepUrl = (u) =>
+        typeof u === 'string' && (/^https?:\/\//.test(u) || u.startsWith('images/')) ? u : null;
+
+    const known = new Set(
+        (await env.DB.prepare('SELECT name FROM emotions').all()).results.map((e) => e.name)
+    );
+    const emotionTags = [...new Set(emotions)].filter((e) => known.has(e));
+
+    const workId = `w_${crypto.randomUUID()}`;
+    const now = Math.floor(Date.now() / 1000);
+    const lengths = ['very_short', 'short', 'medium', 'long'];
+
+    const statements = [
+        env.DB.prepare(
+            `INSERT INTO works (id, owner_id, kind, title, genre, language, length, source, visibility, cover_image_url, created_at)
+             VALUES (?, 'guest', 'story', ?, ?, ?, ?, 'user', ?, ?, ?)`
+        ).bind(
+            workId,
+            title.trim().slice(0, 200),
+            genre ? String(genre).trim().slice(0, 40).toLowerCase() : null,
+            String(language).slice(0, 10),
+            lengths.includes(length) ? length : null,
+            visibility,
+            keepUrl(cover_image_url),
+            now
+        ),
+        ...scenes.map((s, i) =>
+            env.DB.prepare(
+                `INSERT INTO scenes (id, work_id, idx, display_text, narration_text, image_prompt, image_url)
+                 VALUES (?, ?, ?, ?, ?, ?, ?)`
+            ).bind(
+                `sc_${crypto.randomUUID()}`,
+                workId,
+                i,
+                s.display_text.trim(),
+                s.narration_text ? String(s.narration_text).trim() : null,
+                s.image_prompt ? String(s.image_prompt).slice(0, 2000) : null,
+                keepUrl(s.image_url)
+            )
+        ),
+        ...emotionTags.map((e) =>
+            env.DB.prepare('INSERT INTO work_emotions (work_id, emotion) VALUES (?, ?)').bind(workId, e)
+        ),
+    ];
+
+    await env.DB.batch(statements);
+    return json({ id: workId, visibility }, 201);
+}
+
 export default {
     async fetch(request, env) {
         const url = new URL(request.url);
@@ -359,6 +446,7 @@ export default {
                     return await handleSpeech(env, body);
                 }
                 if (path === '/generate-story') return await handleGenerateStory(env, anthropic, body);
+                if (path === '/api/works') return await handleCreateWork(env, body);
             }
 
             if (method === 'GET') {

--- a/myproject/worker/migrations/0001_schema.sql
+++ b/myproject/worker/migrations/0001_schema.sql
@@ -1,6 +1,3 @@
--- LISA 1000 schema v1 — see docs/SCHEMA.md for the full design rationale.
--- Apply with: npx wrangler d1 migrations apply lisa1000
-
 CREATE TABLE users (
     id          TEXT PRIMARY KEY,
     handle      TEXT UNIQUE NOT NULL,
@@ -132,8 +129,6 @@ CREATE TABLE animation_clips (
     status       TEXT NOT NULL DEFAULT 'pending',
     UNIQUE (animation_id, idx)
 );
-
--- ---------- Vocabulary + system seeds ----------
 
 INSERT INTO users (id, handle, email, created_at) VALUES
     ('lisa', 'lisa', NULL, 1752624000);

--- a/myproject/worker/migrations/0002_seed_stories.sql
+++ b/myproject/worker/migrations/0002_seed_stories.sql
@@ -1,7 +1,3 @@
--- Seed: the original 10 LISA stories from public/data/stories.json,
--- migrated into works/scenes and owned by the system user 'lisa'.
--- Cover images stay on the static path until assets move to R2.
-
 INSERT INTO works (id, owner_id, kind, title, genre, language, length, source, cover_image_url, created_at) VALUES
     ('w_001', 'lisa', 'story', 'Spot', 'friendship', 'en', 'very_short', 'lisa', 'images/covers/story_1.webp', 1752624000);
 INSERT INTO work_emotions (work_id, emotion) VALUES ('w_001', 'happy');

--- a/myproject/worker/migrations/0003_visibility.sql
+++ b/myproject/worker/migrations/0003_visibility.sql
@@ -1,0 +1,5 @@
+ALTER TABLE works ADD COLUMN visibility TEXT NOT NULL DEFAULT 'private' CHECK (visibility IN ('private','unlisted','public'));
+
+UPDATE works SET visibility = 'public' WHERE owner_id = 'lisa';
+
+CREATE INDEX idx_works_visibility ON works(visibility);

--- a/myproject/worker/migrations/0004_guest_user.sql
+++ b/myproject/worker/migrations/0004_guest_user.sql
@@ -1,0 +1,2 @@
+INSERT INTO users (id, handle, email, created_at) VALUES
+    ('guest', 'guest', NULL, 1752624000);


### PR DESCRIPTION
## Summary
Generated stories no longer vanish on refresh: a **💾 Save to Library** button appears after generation, asks who should see the story (Everyone / only people with the link), and persists it through the new `POST /api/works` — where it immediately shows up in the Library via the existing works API.

> Also carries two commits the #11 merge missed: comment-free migrations (D1 console compatibility) and `works.visibility` + its API enforcement.

## Changes
**Worker**
- `POST /api/works` — validates and batch-inserts a work + paragraph scenes (with their emotional-cue narration) + emotion tags in one atomic D1 batch.
- Pre-auth ownership: saves belong to a new `guest` system user (migration `0004_guest_user.sql`); `source='user'` keeps them distinct from Lisa's.
- Visibility: accepts `public` | `unlisted` only — a `private` guest work would be orphaned (nobody could ever retrieve it), so private unlocks with accounts.
- Cost guardrail: generated covers arrive as multi-MB base64 data URLs and are **not** stored in D1 rows — real URLs/static paths persist, data URLs get a placeholder until the R2 upload follow-up.
- Input guardrails: title required (≤200 chars), ≤50 scenes with length caps, emotion tags filtered against the vocabulary table.

**Create Story page**
- Save button with visibility dialog (dark-themed SweetAlert2, `confirm()` fallback), saving/saved/error states, and toasts.
- Translating before saving saves the translated text tagged with its language.

## Deployment
One console paste on the live D1 (or `wrangler d1 migrations apply`):
```sql
INSERT INTO users (id, handle, email, created_at) VALUES ('guest', 'guest', NULL, 1752624000);
```
(Plus migration 0003 from #11 if not yet applied — it already is on the live DB.)

## Verification
- End-to-end in Chromium against a stub backend: generate → save (visibility dialog) → story listed in the Library → expand loads its scenes; zero console errors.
- Insert statements validated against the real migration chain (0001–0004) in SQLite.
- `worker/index.js` and `createStory.js` pass syntax checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQ4z1UjkAX1CmARqvFi92f

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQ4z1UjkAX1CmARqvFi92f)_