### PR TITLE
Library filter chips + R2 storage for generated covers

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -27,6 +27,7 @@ goes to lisa1000.com.
 
    Set all three production secrets:
    ```bash
+   npx wrangler r2 bucket create lisa1000-media # once; or dashboard: R2 -> Create bucket
    npx wrangler d1 create lisa1000             # once; paste database_id into wrangler.jsonc
    npx wrangler d1 migrations apply lisa1000 --remote   # schema + seed stories (docs/SCHEMA.md)
    npx wrangler secret put ANTHROPIC_API_KEY   # Claude: stories, definitions, translation

--- a/myproject/public/css/style.css
+++ b/myproject/public/css/style.css
@@ -866,6 +866,77 @@ fieldset.extras legend {
     border-radius: 10px;
 }
 
+/* ---------- Library filters ---------- */
+.filter-bar {
+    max-width: 1140px;
+    width: 100%;
+    margin: 0 auto 8px;
+    padding: 0 24px;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.filter-bar.hidden { display: none; }
+
+.filter-group {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.filter-label {
+    width: 52px;
+    flex-shrink: 0;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-faint);
+}
+
+.chip {
+    padding: 6px 14px;
+    font-size: 13px;
+    font-weight: 700;
+    border-radius: 999px;
+    background: transparent;
+    border: 1px solid var(--line);
+    color: var(--text-muted);
+    box-shadow: none;
+    cursor: pointer;
+    transition: border-color 0.2s, color 0.2s, background 0.2s;
+}
+
+.chip:hover {
+    border-color: rgba(196, 181, 253, 0.5);
+    color: #fff;
+    transform: none;
+    box-shadow: none;
+}
+
+.chip.active {
+    background: linear-gradient(135deg, var(--purple), var(--purple-deep));
+    border-color: transparent;
+    color: #fff;
+    box-shadow: 0 4px 14px rgba(139, 92, 246, 0.35);
+}
+
+.library-empty {
+    grid-column: 1 / -1;
+    text-align: center;
+    color: var(--text-muted);
+    padding: 60px 0;
+    font-size: 16px;
+}
+
+@media (max-width: 768px) {
+    .filter-bar { padding: 0 12px; }
+    .filter-label { width: 100%; }
+}
+
 /* ---------- Library cards ---------- */
 #story-list {
     display: grid;

--- a/myproject/public/js/loadStories.js
+++ b/myproject/public/js/loadStories.js
@@ -47,27 +47,84 @@ function buildStoryCard(mainElement, { title, image, excerpt, getFullText }) {
     mainElement.appendChild(card);
 }
 
+function renderWorks(mainElement, works) {
+    mainElement.innerHTML = '';
+    if (!works.length) {
+        const empty = document.createElement('p');
+        empty.className = 'library-empty';
+        empty.textContent = 'No stories match these filters — try widening them.';
+        mainElement.appendChild(empty);
+        return;
+    }
+    works.forEach(work => buildStoryCard(mainElement, {
+        title: work.title,
+        image: work.cover_image_url,
+        excerpt: work.excerpt || '',
+        getFullText: async () => {
+            const full = await fetch(`/api/works/${encodeURIComponent(work.id)}`).then(r => r.json());
+            return (full.scenes || []).map(s => s.display_text).join('\n\n');
+        },
+    }));
+}
+
+// Active filter state; empty string = "All" for that group.
+const libraryFilters = { owner: '', kind: '', genre: '', emotion: '' };
+
+async function fetchWorks() {
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(libraryFilters)) {
+        if (value) params.set(key, value);
+    }
+    const qs = params.toString();
+    const resp = await fetch('/api/works' + (qs ? `?${qs}` : ''));
+    if (!resp.ok) throw new Error(`Works API ${resp.status}`);
+    return (await resp.json()).works || [];
+}
+
+// Fill the genre group with chips for every genre present in the library.
+function buildGenreChips(works) {
+    const group = document.querySelector('.filter-group[data-param="genre"]');
+    const genres = [...new Set(works.map(w => w.genre).filter(Boolean))].sort();
+    genres.forEach(genre => {
+        const chip = document.createElement('button');
+        chip.className = 'chip';
+        chip.setAttribute('data-value', genre);
+        chip.textContent = genre.charAt(0).toUpperCase() + genre.slice(1);
+        group.appendChild(chip);
+    });
+}
+
+function activateFilterBar(mainElement) {
+    const bar = document.getElementById('library-filters');
+    bar.classList.remove('hidden');
+    bar.addEventListener('click', async (event) => {
+        const chip = event.target.closest('.chip');
+        if (!chip) return;
+        const group = chip.closest('.filter-group');
+        group.querySelectorAll('.chip').forEach(c => c.classList.remove('active'));
+        chip.classList.add('active');
+        libraryFilters[group.getAttribute('data-param')] = chip.getAttribute('data-value');
+        try {
+            renderWorks(mainElement, await fetchWorks());
+        } catch (error) {
+            console.error('Error filtering stories:', error);
+        }
+    });
+}
+
 // Works API (D1) first; stories.json as fallback for environments without
-// a database (local Express dev, static preview).
+// a database (local Express dev, static preview). Filters only appear in
+// API mode — the flat JSON has no genre/emotion data to filter on.
 async function loadLibrary() {
     const mainElement = document.getElementById('story-list');
 
     try {
-        const resp = await fetch('/api/works');
-        if (resp.ok) {
-            const { works } = await resp.json();
-            if (works && works.length) {
-                works.forEach(work => buildStoryCard(mainElement, {
-                    title: work.title,
-                    image: work.cover_image_url,
-                    excerpt: work.excerpt || '',
-                    getFullText: async () => {
-                        const full = await fetch(`/api/works/${encodeURIComponent(work.id)}`).then(r => r.json());
-                        return (full.scenes || []).map(s => s.display_text).join('\n\n');
-                    },
-                }));
-                return;
-            }
+        const works = await fetchWorks();
+        if (works.length) {
+            renderWorks(mainElement, works);
+            buildGenreChips(works);
+            activateFilterBar(mainElement);
+            return;
         }
     } catch (error) {
         console.warn('Works API unavailable, falling back to stories.json:', error);

--- a/myproject/public/library.html
+++ b/myproject/public/library.html
@@ -47,6 +47,36 @@
         </div>
     </header>
 
+    <section id="library-filters" class="filter-bar hidden" aria-label="Filter stories">
+        <div class="filter-group" data-param="owner">
+            <span class="filter-label">Who</span>
+            <button class="chip active" data-value="">All</button>
+            <button class="chip" data-value="lisa">✦ Lisa's</button>
+            <button class="chip" data-value="guest">Community</button>
+        </div>
+        <div class="filter-group" data-param="kind">
+            <span class="filter-label">Type</span>
+            <button class="chip active" data-value="">All</button>
+            <button class="chip" data-value="story">📖 Stories</button>
+            <button class="chip" data-value="play">🎭 Plays</button>
+        </div>
+        <div class="filter-group" data-param="genre">
+            <span class="filter-label">Genre</span>
+            <button class="chip active" data-value="">All</button>
+            <!-- genre chips are filled in from the loaded works -->
+        </div>
+        <div class="filter-group" data-param="emotion">
+            <span class="filter-label">Mood</span>
+            <button class="chip active" data-value="">All</button>
+            <button class="chip" data-value="happy">😊 Happy</button>
+            <button class="chip" data-value="sad">😢 Sad</button>
+            <button class="chip" data-value="inspired">🌟 Inspired</button>
+            <button class="chip" data-value="cozy">🕯️ Cozy</button>
+            <button class="chip" data-value="funny">😄 Funny</button>
+            <button class="chip" data-value="excited">⚡ Excited</button>
+        </div>
+    </section>
+
     <main id="story-list">
         <!-- Stories will be loaded here dynamically -->
     </main>

--- a/myproject/worker/index.js
+++ b/myproject/worker/index.js
@@ -342,6 +342,37 @@ async function handleGetWork(env, id) {
     });
 }
 
+// ---------- Media storage (R2) ----------
+
+// Decode a data:image/... URL and store it in the MEDIA bucket.
+// Returns the /media/<key> path the worker serves it back from.
+async function storeDataUrl(env, dataUrl, keyBase) {
+    const match = /^data:(image\/(png|jpeg|webp));base64,(.+)$/.exec(dataUrl);
+    if (!match) throw new Error('Unsupported data URL');
+    const [, contentType, ext, b64] = match;
+
+    const binary = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+    if (binary.length > 8 * 1024 * 1024) throw new Error('Image too large (max 8 MB)');
+
+    const key = `${keyBase}.${ext === 'jpeg' ? 'jpg' : ext}`;
+    await env.MEDIA.put(key, binary, { httpMetadata: { contentType } });
+    return `/media/${key}`;
+}
+
+// GET /media/* — serve R2 objects (covers now; audio/clips later).
+async function handleMedia(env, path) {
+    if (!env.MEDIA) return json({ error: 'Media storage not configured' }, 501);
+    const key = decodeURIComponent(path.slice('/media/'.length));
+    const object = await env.MEDIA.get(key);
+    if (!object) return json({ error: 'Not found' }, 404);
+    return new Response(object.body, {
+        headers: {
+            'Content-Type': object.httpMetadata?.contentType || 'application/octet-stream',
+            'Cache-Control': 'public, max-age=31536000, immutable',
+        },
+    });
+}
+
 // POST /api/works — persist a generated story into the library.
 // Pre-auth, works are owned by the 'guest' system user; the client offers
 // 'public' or 'unlisted'. 'private' arrives with accounts (a private guest
@@ -377,11 +408,12 @@ async function handleCreateWork(env, body) {
         }
     }
 
-    // Only persist real URLs / static paths. Generated covers arrive as
-    // multi-MB base64 data URLs — storing those in D1 rows is the expensive
-    // mistake; they get an R2 upload in a follow-up and a placeholder for now.
+    // Real URLs / static paths persist as-is. Generated covers arrive as
+    // multi-MB base64 data URLs: with an R2 binding they're uploaded and the
+    // row stores a small /media/... path; without one they're dropped (a
+    // data URL in a D1 row is the expensive mistake).
     const keepUrl = (u) =>
-        typeof u === 'string' && (/^https?:\/\//.test(u) || u.startsWith('images/')) ? u : null;
+        typeof u === 'string' && (/^https?:\/\//.test(u) || u.startsWith('images/') || u.startsWith('/media/')) ? u : null;
 
     const known = new Set(
         (await env.DB.prepare('SELECT name FROM emotions').all()).results.map((e) => e.name)
@@ -391,6 +423,16 @@ async function handleCreateWork(env, body) {
     const workId = `w_${crypto.randomUUID()}`;
     const now = Math.floor(Date.now() / 1000);
     const lengths = ['very_short', 'short', 'medium', 'long'];
+
+    // Upload a data-URL cover to R2 and reference it by path instead.
+    let coverUrl = keepUrl(cover_image_url);
+    if (!coverUrl && env.MEDIA && typeof cover_image_url === 'string' && cover_image_url.startsWith('data:image/')) {
+        try {
+            coverUrl = await storeDataUrl(env, cover_image_url, `covers/${workId}`);
+        } catch (error) {
+            console.error('Cover upload to R2 failed, saving without cover:', error.message);
+        }
+    }
 
     const statements = [
         env.DB.prepare(
@@ -403,7 +445,7 @@ async function handleCreateWork(env, body) {
             String(language).slice(0, 10),
             lengths.includes(length) ? length : null,
             visibility,
-            keepUrl(cover_image_url),
+            coverUrl,
             now
         ),
         ...scenes.map((s, i) =>
@@ -450,6 +492,7 @@ export default {
             }
 
             if (method === 'GET') {
+                if (path.startsWith('/media/')) return await handleMedia(env, path);
                 if (path === '/api/works') return await handleListWorks(env, url);
                 if (path.startsWith('/api/works/')) {
                     return await handleGetWork(env, decodeURIComponent(path.slice('/api/works/'.length)));

--- a/myproject/wrangler.jsonc
+++ b/myproject/wrangler.jsonc
@@ -23,5 +23,15 @@
             "database_id": "d6abaac2-b196-4dd6-abab-44ef01b58e5d",
             "migrations_dir": "worker/migrations"
         }
+    ],
+    // R2 bucket for generated media (story covers now; narration audio and
+    // animation clips later). One-time setup in the dashboard:
+    //   R2 Object Storage -> Create bucket -> name it "lisa1000-media"
+    // (no public access needed — the worker serves objects via /media/*)
+    "r2_buckets": [
+        {
+            "binding": "MEDIA",
+            "bucket_name": "lisa1000-media"
+        }
     ]
 }


### PR DESCRIPTION
## Summary
Two features: the Library gets filter chips wired to the works API, and generated story covers move to R2 so saved stories keep their illustrations without bloating D1.

## Library filters
- Chip groups above the grid — **Who** (All / ✦ Lisa's / Community), **Type** (📖 Stories / 🎭 Plays), **Genre** (chips built dynamically from whatever genres exist in the library), **Mood** (the emotion vocabulary with emoji).
- Each selection refetches `/api/works` with the matching query params; filters compose (e.g. Lisa's + adventure + happy).
- Friendly empty state when nothing matches. The bar only appears in API mode — the `stories.json` fallback has no genre/emotion data to filter on.

## R2 covers
- New `MEDIA` bucket binding (`lisa1000-media`) in `wrangler.jsonc`.
- `POST /api/works` now uploads a generated base64 cover to R2 (`covers/<workId>.png`, 8 MB cap) and stores the small `/media/...` path on the row — replacing the letter-placeholder behavior from #12. Absent binding or failed upload degrades to no cover, never a failed save.
- The worker serves objects via `GET /media/*` with `Cache-Control: immutable`, so no public-bucket setup is needed.

## Deployment (one-time)
Create the bucket — dashboard: **R2 Object Storage → Create bucket → `lisa1000-media`** (or `npx wrangler r2 bucket create lisa1000-media`). No public access needed. DEPLOY.md updated.

## Verification
- Chromium against a stub API: all chip groups filter and compose correctly, genre chips build from data, empty state renders, zero console errors (screenshot-verified).
- R2 data-URL decoder unit-checked (content type, key extension, byte decode).
- `worker/index.js` and `loadStories.js` pass syntax checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQ4z1UjkAX1CmARqvFi92f

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQ4z1UjkAX1CmARqvFi92f)_