### PR TITLE
Ride out Claude 529 overloads; warn before navigating away mid-generation

### DIFF
--- a/myproject/public/css/style.css
+++ b/myproject/public/css/style.css
@@ -961,6 +961,12 @@ fieldset.extras legend {
     color: var(--text-muted);
 }
 
+.loading-hint {
+    font-size: 13px;
+    color: var(--text-faint);
+    margin: 0;
+}
+
 .popup .def-body h4 {
     margin: 14px 0 4px;
     font-family: 'Karla', sans-serif;

--- a/myproject/public/js/createStory.js
+++ b/myproject/public/js/createStory.js
@@ -43,33 +43,52 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 });
 
+// Why the last generation failed, for the error card shown to the user.
+let lastGenerationError = '';
+
 async function generateStory(prompt) {
     console.log('Contacting story server with prompt:', prompt); // Debugging code
+    lastGenerationError = '';
 
-    try {
-        const response = await fetch('/generate-story', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({ prompt: prompt })
-        });
+    // One request + one automatic retry when the server says the failure is
+    // temporary (Claude overloaded / rate limited). The backend SDK already
+    // retries with backoff, so anything reaching us here was busy for a while.
+    for (let attempt = 0; attempt < 2; attempt++) {
+        try {
+            const response = await fetch('/generate-story', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ prompt: prompt })
+            });
 
-        if (!response.ok) {
-            const errBody = await response.text().catch(() => '');
-            console.error('Server error body:', errBody);
-            throw new Error(`Server error ${response.status}: ${errBody}`);
+            if (!response.ok) {
+                const errBody = await response.text().catch(() => '');
+                console.error('Server error body:', errBody);
+                let parsed = {};
+                try { parsed = JSON.parse(errBody); } catch (_) { /* not JSON */ }
+                lastGenerationError = parsed.error || `The story server returned an error (${response.status}).`;
+                if (parsed.retryable && attempt === 0) {
+                    console.log('Temporary overload — retrying once in 8s...');
+                    await new Promise((r) => setTimeout(r, 8000));
+                    continue;
+                }
+                return null;
+            }
+
+            const data = await response.json();
+            console.log('Received story from server:', data.story); // Debugging code
+            console.log('Received image URL from server:', data.imageUrl); // Debugging code
+
+            return data;
+        } catch (error) {
+            console.error('Network or server error:', error);
+            lastGenerationError = 'Could not reach the story server — check your connection and try again.';
+            return null;
         }
-
-        const data = await response.json();
-        console.log('Received story from server:', data.story); // Debugging code
-        console.log('Received image URL from server:', data.imageUrl); // Debugging code
-
-        return data;
-    } catch (error) {
-        console.error('Network or server error:', error);
-        return null;
     }
+    return null;
 }
 
 document.addEventListener('DOMContentLoaded', function() {
@@ -192,20 +211,34 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     });
 
+    // Warn before leaving the page while a story is generating — navigating
+    // to another tab/page aborts the request and the story is lost.
+    let generationInFlight = false;
+    window.addEventListener('beforeunload', function(event) {
+        if (generationInFlight) {
+            event.preventDefault();
+            event.returnValue = 'Your story is still being created — leaving now will lose it.';
+        }
+    });
+
     // Show a staged loading indicator while the story + image generate (~20-60s)
     function startLoading(triggerButton) {
         const stages = [
             "Lisa is writing your story...",
             "Illustrating your story...",
-            "Adding the finishing touches..."
+            "Adding the finishing touches...",
+            "Still working — Lisa is being extra careful..."
         ];
         let stageIndex = 0;
+        generationInFlight = true;
         if (triggerButton) triggerButton.disabled = true;
         buttonContainer.style.display = 'none';
+        storyContainer.classList.remove('generated-story');
         storyContainer.innerHTML = `
             <div class="loading-overlay">
                 <div class="spinner"></div>
                 <p class="loading-status">${stages[0]}</p>
+                <p class="loading-hint">Please stay on this page — leaving stops the magic. ✨</p>
             </div>`;
         const timer = setInterval(() => {
             stageIndex = Math.min(stageIndex + 1, stages.length - 1);
@@ -214,13 +247,18 @@ document.addEventListener('DOMContentLoaded', function() {
         }, 15000);
         return function stopLoading() {
             clearInterval(timer);
+            generationInFlight = false;
             if (triggerButton) triggerButton.disabled = false;
         };
     }
 
     function displayStory(story, imageUrl, title = 'Generated Story') {
         if (!story) {
-            storyContainer.innerHTML = '<h2>Failed to generate story</h2>';
+            storyContainer.classList.add('generated-story');
+            storyContainer.innerHTML = `
+                <h2>Couldn't create your story</h2>
+                <p>${lastGenerationError || 'Something went wrong on our side.'}</p>
+                <p>Everything you filled in is still here — just press Generate again.</p>`;
             return;
         }
         console.log('Displaying story:', story); // Debugging code

--- a/myproject/server.js
+++ b/myproject/server.js
@@ -11,7 +11,9 @@ app.use(cors()); // Enable CORS for all routes
 const PORT = process.env.PORT || 3000;
 app.use(express.static('public'));
 
-const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+// maxRetries: the SDK retries transient failures (429 rate limit, 529
+// overloaded, 5xx) with exponential backoff before giving up.
+const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY, maxRetries: 5 });
 
 // Higgsfield reads HF_CREDENTIALS ("KEY_ID:KEY_SECRET") from the environment.
 // OpenAI is kept for text-to-speech only (Claude does not generate audio).

--- a/myproject/worker/index.js
+++ b/myproject/worker/index.js
@@ -436,7 +436,9 @@ export default {
         const method = request.method;
 
         try {
-            const anthropic = new Anthropic({ apiKey: env.ANTHROPIC_API_KEY });
+            // maxRetries: the SDK retries transient failures (429 rate limit,
+            // 529 overloaded, 5xx) with exponential backoff before giving up.
+            const anthropic = new Anthropic({ apiKey: env.ANTHROPIC_API_KEY, maxRetries: 5 });
             if (method === 'POST') {
                 const body = await request.json().catch(() => ({}));
 
@@ -463,9 +465,19 @@ export default {
             return json({ error: 'Not found' }, 404);
         } catch (error) {
             console.error(`Error handling ${method} ${path}:`, error);
+            const detail = String(error?.message || error);
+            // Anthropic overload/rate-limit that survived the SDK's retries:
+            // tell the user it's temporary rather than "Internal error".
+            if (/overloaded|529|rate.?limit|429/i.test(detail)) {
+                return json({
+                    error: "Lisa's AI is very popular right now — please try again in a minute.",
+                    detail,
+                    retryable: true,
+                }, 503);
+            }
             // Surface the underlying cause so failures are debuggable from the
             // browser Network tab (no key material is ever in these messages).
-            return json({ error: 'Internal error', detail: String(error?.message || error) }, 500);
+            return json({ error: 'Internal error', detail }, 500);
         }
     },
 };


### PR DESCRIPTION
## Summary
Fixes the two issues from today's testing: the raw `529 Overloaded` failure from Anthropic, and losing an in-flight story when navigating to another page.

## Overload resilience
The 529 is Anthropic's transient "try again shortly" signal, but it surfaced as a one-shot `Internal error` 500. Now there are three layers between the user and it:
1. **SDK retries** — the Anthropic clients in both the worker and the Express server use `maxRetries: 5`, retrying 429/529/5xx with exponential backoff.
2. **Honest error type** — an overload/rate-limit that survives all retries returns **503 + `retryable: true`** with a human message ("Lisa's AI is very popular right now…") instead of `Internal error`.
3. **Client auto-retry + friendly failure card** — the client retries a retryable response once after 8s; if it still fails, the story area shows a card explaining what happened and that the form is untouched, replacing the bare "Failed to generate story".

## Navigation guard
Leaving the page mid-generation aborts the request and the story is silently lost (full page navigations, no SPA). Now:
- a `beforeunload` guard prompts "your story is still being created — leaving now will lose it" whenever a generation is in flight;
- the loading overlay says to stay on the page, and gains a fourth long-wait stage message.

## Verification (Chromium against a stub backend)
- 503-then-success recovers via the auto-retry and delivers the story.
- The beforeunload dialog fires and navigation is blocked during loading.
- Permanent failure renders the friendly error card.
- Zero console errors; all three JS files pass syntax checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQ4z1UjkAX1CmARqvFi92f

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQ4z1UjkAX1CmARqvFi92f)_