### PR TITLE
Keep all hero covers visible on small screens with a heavy fade

### DIFF
--- a/myproject/public/css/style.css
+++ b/myproject/public/css/style.css
@@ -348,18 +348,21 @@ header { background: transparent; }
 .star-field .star.gold i { color: var(--amber); }
 
 /* On smaller screens keep two covers, faded behind the hero text */
+/* On smaller screens the covers never disappear — they all slip behind the
+   hero text with a much heavier fade, spread along the edges. */
 @media (max-width: 1240px) {
-    .hero-float.bottom-left, .hero-float.bottom-right,
-    .hero-float.mid-left, .hero-float.mid-right { display: none; }
-
-    .hero-float.left, .hero-float.right {
+    .hero-float {
         z-index: 0;
-        opacity: 0.3;
-        width: 150px;
+        opacity: 0.14;
+        width: 120px;
     }
 
-    .hero-float.left { left: -30px; top: 12%; }
-    .hero-float.right { right: -30px; top: 55%; }
+    .hero-float.left  { left: -30px; top: 10%; opacity: 0.3; width: 150px; }
+    .hero-float.right { right: -30px; top: 55%; opacity: 0.3; width: 150px; }
+    .hero-float.mid-left     { left: -40px; top: 38%; opacity: 0.14; }
+    .hero-float.mid-right    { right: -40px; top: 80%; opacity: 0.14; }
+    .hero-float.bottom-left  { left: 22%; top: 82%; }
+    .hero-float.bottom-right { right: 55%; top: 3%; left: auto; }
 }
 
 /* ---------- Page header (Library / Create Story) ---------- */


### PR DESCRIPTION
## Summary
On screens below 1240px, four of the six hero covers were `display: none`. Per feedback, covers should never disappear on responsive layouts — they now all stay rendered, slipped behind the hero text with a much heavier fade.

## Changes
- All six `.hero-float` covers remain visible at every width: the two main covers at **0.3 opacity**, the other four at **0.14**, sized down to 120–150px and spread along the hero's edges (`z-index: 0`, behind the text).
- Explicit opacity override for `mid-left`/`mid-right`, whose desktop `0.55` rule otherwise wins on specificity.

## Verification
Computed styles checked at 390px and 900px viewports: all six covers `display: block` at the intended opacities; mobile screenshot confirms the hero text stays fully legible over the faded collage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQ4z1UjkAX1CmARqvFi92f

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQ4z1UjkAX1CmARqvFi92f)_