### PR TITLE
Never crop cover art: blurred letterbox frames on library cards and story pages

### DIFF
--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -253,6 +253,13 @@ CREATE TABLE animation_clips (
 Animations **reference** the work's scenes via clips — they never copy them.
 Ten renders of one work share the same scene data.
 
+**Product note (monetization):** finished animations are the premium surface.
+They are listed publicly in the Animate tab but shown **fully blurred** until
+the viewer has an account and an active subscription — the blur is the
+paywall. (The same `.cover-frame` blur technique used for library covers
+provides the visual language.) Requires `users` + subscription state; noted
+here so nothing in the schema blocks it.
+
 ---
 
 ## 3. Relationship map

--- a/myproject/public/css/style.css
+++ b/myproject/public/css/style.css
@@ -890,14 +890,37 @@ fieldset.extras legend {
 
 .back-link:hover { color: #fff; }
 
-#story-cover {
-    display: block;
+/* Non-destructive cover frame: the full artwork is letterboxed (contain,
+   never cropped) inside a 16:9 frame; the empty sides are filled by a
+   blurred, dimmed copy of the same image. */
+.cover-frame {
+    position: relative;
     width: 100%;
-    max-height: 340px;
-    object-fit: cover;
+    aspect-ratio: 16 / 9;
+    overflow: hidden;
+    background: rgba(139, 92, 246, 0.12);
 }
 
-#story-cover.hidden { display: none; }
+.cover-frame-bg {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    filter: blur(26px) brightness(0.7) saturate(1.1);
+    transform: scale(1.2);
+}
+
+.cover-frame-fg,
+#story-cover {
+    position: relative;
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}
+
+#story-cover-wrap.hidden { display: none; }
 
 .story-card-link { cursor: pointer; }
 
@@ -1001,13 +1024,7 @@ fieldset.extras legend {
     box-shadow: 0 20px 50px rgba(0, 0, 0, 0.5);
 }
 
-.story-card img {
-    width: 100%;
-    aspect-ratio: 16 / 9;
-    object-fit: cover;
-    display: block;
-    background: rgba(139, 92, 246, 0.12);
-}
+.story-card .cover-frame { flex-shrink: 0; }
 
 .cover-placeholder {
     width: 100%;

--- a/myproject/public/js/loadStories.js
+++ b/myproject/public/js/loadStories.js
@@ -5,8 +5,20 @@ function buildStoryCard(mainElement, { title, image, excerpt, href }) {
     card.className = 'story-card story-card-link';
     card.addEventListener('click', () => { window.location.href = href; });
 
-    // Cover image, with a lettered placeholder if the file is missing
+    // Cover artwork, never cropped: letterboxed in a 16:9 frame whose sides
+    // are a blurred copy of the same image. Lettered placeholder if missing.
+    const frame = document.createElement('div');
+    frame.className = 'cover-frame card-cover';
+
+    const coverBg = document.createElement('img');
+    coverBg.className = 'cover-frame-bg';
+    coverBg.src = image || '';
+    coverBg.alt = '';
+    coverBg.setAttribute('aria-hidden', 'true');
+    coverBg.loading = 'lazy';
+
     const cover = document.createElement('img');
+    cover.className = 'cover-frame-fg';
     cover.src = image || '';
     cover.alt = `${title} cover`;
     cover.loading = 'lazy';
@@ -14,9 +26,12 @@ function buildStoryCard(mainElement, { title, image, excerpt, href }) {
         const placeholder = document.createElement('div');
         placeholder.className = 'cover-placeholder';
         placeholder.textContent = title.charAt(0);
-        this.replaceWith(placeholder);
+        frame.replaceWith(placeholder);
     };
-    card.appendChild(cover);
+
+    frame.appendChild(coverBg);
+    frame.appendChild(cover);
+    card.appendChild(frame);
 
     const body = document.createElement('div');
     body.className = 'card-body';

--- a/myproject/public/js/storyPage.js
+++ b/myproject/public/js/storyPage.js
@@ -63,6 +63,8 @@ async function renderStory() {
     const titleEl = document.getElementById('story-title');
     const contentEl = document.getElementById('story-content');
     const coverEl = document.getElementById('story-cover');
+    const coverBgEl = document.getElementById('story-cover-bg');
+    const coverWrapEl = document.getElementById('story-cover-wrap');
 
     const story = await fetchStory();
     if (!story) {
@@ -78,10 +80,13 @@ async function renderStory() {
     titleEl.textContent = story.title;
     contentEl.innerHTML = story.paragraphs.map((p) => `<p>${p}</p>`).join('');
     if (story.cover) {
+        // Full artwork, never cropped: the cover is letterboxed inside a
+        // 16:9 frame whose sides are a blurred copy of the same image.
         coverEl.src = story.cover;
+        coverBgEl.src = story.cover;
         coverEl.alt = `${story.title} cover`;
-        coverEl.classList.remove('hidden');
-        coverEl.onerror = () => coverEl.classList.add('hidden');
+        coverWrapEl.classList.remove('hidden');
+        coverEl.onerror = () => coverWrapEl.classList.add('hidden');
     }
 }
 

--- a/myproject/public/story.html
+++ b/myproject/public/story.html
@@ -41,7 +41,10 @@
     <main class="story-page-main">
         <a href="library.html" class="back-link">← Back to the Library</a>
         <article id="story-container">
-            <img id="story-cover" alt="" class="hidden">
+            <div id="story-cover-wrap" class="cover-frame hidden">
+                <img id="story-cover-bg" class="cover-frame-bg" alt="" aria-hidden="true">
+                <img id="story-cover" alt="">
+            </div>
             <h2 id="story-title">Loading story…</h2>
             <div id="story-content"></div>
             <p class="reader-hint">💡 Double-click any word for its meaning, pronunciation, or translation.</p>

--- a/myproject/server.js
+++ b/myproject/server.js
@@ -305,7 +305,13 @@ app.get('/definition/:word', async (req, res) => {
 });
 
 
-// Endpoint for generating a story (Claude) and an illustration (Higgsfield Soul)
+// House art style for every illustration — matches the original 10 story
+// covers. The model supplies only the scene; the style is enforced here.
+const IMAGE_STYLE_PREFIX =
+    "Children's storybook illustration, warm whimsical hand-painted style, " +
+    'soft colors, gentle light, painterly gouache texture, cozy and friendly: ';
+
+// Endpoint for generating a story and an illustration
 app.post('/generate-story', async (req, res) => {
     const prompt = req.body.prompt;
     if (!prompt) {
@@ -313,11 +319,12 @@ app.post('/generate-story', async (req, res) => {
     }
     try {
         const { text } = await generateText({
-            system: 'You are a helpful assistant designed to write short stories. Output plain text in exactly this format: title|story|narration|imagePrompt. '
+            system: 'LISA 1000 is a language-learning product for young children and educators. Everything you write MUST be appropriate for children aged 4-10: kind, gentle, and positive, with simple vocabulary. Absolutely no violence, horror, romance, or adult themes. If the request asks for unsuitable content, do not refuse — instead write a gentle, age-appropriate story on the nearest safe theme. '
+                + 'You are a helpful assistant designed to write short stories. Output plain text in exactly this format: title|story|narration|imagePrompt. '
                 + 'The title is a short, evocative story title (a few words, no quotes). '
                 + 'The story is the clean text shown to the reader. It must NOT repeat the title. '
                 + 'The narration is the SAME story with inline emotional delivery cues in square brackets placed before the phrases they affect — e.g. [warmly], [excited], [whispers], [sighs], [laughs] — for an expressive text-to-speech narrator. '
-                + 'The imagePrompt is a highly detailed illustration prompt for the story. '
+                + 'The imagePrompt describes only the SCENE to illustrate (characters, setting, moment) — no art style, which is applied automatically. '
                 + 'Output exactly three "|" characters separating the four parts, and nothing else — no labels, no markdown.',
             prompt,
             maxTokens: 8192,
@@ -330,7 +337,7 @@ app.post('/generate-story', async (req, res) => {
         // higgsfield.subscribe('/v1/text2image/soul', { input: { prompt, ... }, withPolling: true })
         const imageResponse = await openai.images.generate({
             model: 'gpt-image-2',
-            prompt: (imagePrompt || story).substring(0, 1000),
+            prompt: IMAGE_STYLE_PREFIX + (imagePrompt || story).substring(0, 1000),
             size: '1024x1024',
         });
 

--- a/myproject/server.js
+++ b/myproject/server.js
@@ -305,12 +305,6 @@ app.get('/definition/:word', async (req, res) => {
 });
 
 
-// House art style for every illustration — matches the original 10 story
-// covers. The model supplies only the scene; the style is enforced here.
-const IMAGE_STYLE_PREFIX =
-    "Children's storybook illustration, warm whimsical hand-painted style, " +
-    'soft colors, gentle light, painterly gouache texture, cozy and friendly: ';
-
 // Endpoint for generating a story and an illustration
 app.post('/generate-story', async (req, res) => {
     const prompt = req.body.prompt;
@@ -319,12 +313,11 @@ app.post('/generate-story', async (req, res) => {
     }
     try {
         const { text } = await generateText({
-            system: 'LISA 1000 is a language-learning product for young children and educators. Everything you write MUST be appropriate for children aged 4-10: kind, gentle, and positive, with simple vocabulary. Absolutely no violence, horror, romance, or adult themes. If the request asks for unsuitable content, do not refuse — instead write a gentle, age-appropriate story on the nearest safe theme. '
-                + 'You are a helpful assistant designed to write short stories. Output plain text in exactly this format: title|story|narration|imagePrompt. '
+            system: 'You are a helpful assistant designed to write short stories. Output plain text in exactly this format: title|story|narration|imagePrompt. '
                 + 'The title is a short, evocative story title (a few words, no quotes). '
                 + 'The story is the clean text shown to the reader. It must NOT repeat the title. '
                 + 'The narration is the SAME story with inline emotional delivery cues in square brackets placed before the phrases they affect — e.g. [warmly], [excited], [whispers], [sighs], [laughs] — for an expressive text-to-speech narrator. '
-                + 'The imagePrompt describes only the SCENE to illustrate (characters, setting, moment) — no art style, which is applied automatically. '
+                + 'The imagePrompt is a highly detailed illustration prompt for the story. '
                 + 'Output exactly three "|" characters separating the four parts, and nothing else — no labels, no markdown.',
             prompt,
             maxTokens: 8192,
@@ -337,7 +330,7 @@ app.post('/generate-story', async (req, res) => {
         // higgsfield.subscribe('/v1/text2image/soul', { input: { prompt, ... }, withPolling: true })
         const imageResponse = await openai.images.generate({
             model: 'gpt-image-2',
-            prompt: IMAGE_STYLE_PREFIX + (imagePrompt || story).substring(0, 1000),
+            prompt: (imagePrompt || story).substring(0, 1000),
             size: '1024x1024',
         });
 

--- a/myproject/worker/index.js
+++ b/myproject/worker/index.js
@@ -236,6 +236,12 @@ async function handleSpeech(env, body) {
 
 // OpenAI GPT Image text-to-image (current image provider).
 // GPT Image models return base64, not a hosted URL, so we hand back a data URL.
+// House art style for every illustration — matches the original 10 story
+// covers. The model supplies only the scene; the style is enforced here.
+const IMAGE_STYLE_PREFIX =
+    "Children's storybook illustration, warm whimsical hand-painted style, " +
+    'soft colors, gentle light, painterly gouache texture, cozy and friendly: ';
+
 async function generateIllustrationOpenAI(env, prompt) {
     const resp = await fetch('https://api.openai.com/v1/images/generations', {
         method: 'POST',
@@ -243,7 +249,7 @@ async function generateIllustrationOpenAI(env, prompt) {
             'Authorization': `Bearer ${env.OPENAI_API_KEY}`,
             'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ model: 'gpt-image-2', prompt, size: '1024x1024' }),
+        body: JSON.stringify({ model: 'gpt-image-2', prompt: IMAGE_STYLE_PREFIX + prompt, size: '1024x1024' }),
     });
     if (!resp.ok) {
         throw new Error(`OpenAI image generation failed (${resp.status}): ${await resp.text()}`);
@@ -292,11 +298,12 @@ async function generateIllustration(env, prompt) {
 }
 
 const STORY_SYSTEM_PROMPT =
+    'LISA 1000 is a language-learning product for young children and educators. Everything you write MUST be appropriate for children aged 4-10: kind, gentle, and positive, with simple vocabulary. Absolutely no violence, horror, romance, or adult themes. If the request asks for unsuitable content, do not refuse — instead write a gentle, age-appropriate story on the nearest safe theme. ' +
     'You are a helpful assistant designed to write short stories. Output plain text in exactly this format: title|story|narration|imagePrompt. ' +
     'The title is a short, evocative story title (a few words, no quotes). ' +
     'The story is the clean text shown to the reader. It must NOT repeat the title. ' +
     'The narration is the SAME story with inline emotional delivery cues in square brackets placed before the phrases they affect — e.g. [warmly], [excited], [whispers], [sighs], [laughs] — for an expressive text-to-speech narrator. ' +
-    'The imagePrompt is a highly detailed illustration prompt for the story. ' +
+    'The imagePrompt describes only the SCENE to illustrate (characters, setting, moment) — no art style, which is applied automatically. ' +
     'Output exactly three "|" characters separating the four parts, and nothing else — no labels, no markdown.';
 
 // Split a title|story|narration|imagePrompt response, tolerating models that

--- a/myproject/worker/index.js
+++ b/myproject/worker/index.js
@@ -236,12 +236,6 @@ async function handleSpeech(env, body) {
 
 // OpenAI GPT Image text-to-image (current image provider).
 // GPT Image models return base64, not a hosted URL, so we hand back a data URL.
-// House art style for every illustration — matches the original 10 story
-// covers. The model supplies only the scene; the style is enforced here.
-const IMAGE_STYLE_PREFIX =
-    "Children's storybook illustration, warm whimsical hand-painted style, " +
-    'soft colors, gentle light, painterly gouache texture, cozy and friendly: ';
-
 async function generateIllustrationOpenAI(env, prompt) {
     const resp = await fetch('https://api.openai.com/v1/images/generations', {
         method: 'POST',
@@ -249,7 +243,7 @@ async function generateIllustrationOpenAI(env, prompt) {
             'Authorization': `Bearer ${env.OPENAI_API_KEY}`,
             'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ model: 'gpt-image-2', prompt: IMAGE_STYLE_PREFIX + prompt, size: '1024x1024' }),
+        body: JSON.stringify({ model: 'gpt-image-2', prompt, size: '1024x1024' }),
     });
     if (!resp.ok) {
         throw new Error(`OpenAI image generation failed (${resp.status}): ${await resp.text()}`);
@@ -298,12 +292,11 @@ async function generateIllustration(env, prompt) {
 }
 
 const STORY_SYSTEM_PROMPT =
-    'LISA 1000 is a language-learning product for young children and educators. Everything you write MUST be appropriate for children aged 4-10: kind, gentle, and positive, with simple vocabulary. Absolutely no violence, horror, romance, or adult themes. If the request asks for unsuitable content, do not refuse — instead write a gentle, age-appropriate story on the nearest safe theme. ' +
     'You are a helpful assistant designed to write short stories. Output plain text in exactly this format: title|story|narration|imagePrompt. ' +
     'The title is a short, evocative story title (a few words, no quotes). ' +
     'The story is the clean text shown to the reader. It must NOT repeat the title. ' +
     'The narration is the SAME story with inline emotional delivery cues in square brackets placed before the phrases they affect — e.g. [warmly], [excited], [whispers], [sighs], [laughs] — for an expressive text-to-speech narrator. ' +
-    'The imagePrompt describes only the SCENE to illustrate (characters, setting, moment) — no art style, which is applied automatically. ' +
+    'The imagePrompt is a highly detailed illustration prompt for the story. ' +
     'Output exactly three "|" characters separating the four parts, and nothing else — no labels, no markdown.';
 
 // Split a title|story|narration|imagePrompt response, tolerating models that


### PR DESCRIPTION
## Summary
Cover art is never visually cropped again — the full artwork is always shown, letterboxed inside a 16:9 frame whose sides are a blurred copy of the same image.

> **Scope note:** this PR originally also hardcoded a house art style and children-content guardrails; both were **rolled back** per review — story confrontation ≠ violence, and art style / content profile belong to educator settings later, after the whole app is built. The diff is now cover frames + a docs note only.

## The crop fix
First, the reassurance: **stored covers were never cropped** — R2/static files keep the full image; the "cuts" were display-only (`object-fit: cover` squeezing square art into 16:9 boxes) but were eating baked-in title text ("The Polished Car", "The Rhino's Big Snowy Adventure").

- New **`.cover-frame`**: full artwork letterboxed (`object-fit: contain`), empty sides filled by a **blurred, dimmed copy of the same image** — "blur the sides, not the art".
- Applied to **library cards** and the **story page** (whose old `max-height: 340px` crop is gone). Lettered placeholders unchanged.
- The card shows the full cover as a tease; clicking through reveals it large — the sense-of-discovery flow.

## Docs
- `SCHEMA.md` records the monetization insight for later: finished animations list publicly but **fully blurred** until sign-up + subscription — the blur is the paywall, reusing this same frame technique.

## Verification
Chromium checks on library and story pages: full uncropped artwork renders with blurred letterbox sides (computed styles verified: foreground `contain`, background blur), placeholders intact, zero console errors. Screenshot-verified against the previously-cut covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQ4z1UjkAX1CmARqvFi92f