### PR TITLE
Engagement, My Stories, Higgsfield cartoon images, and the starry-night redesign

### DIFF
--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -154,7 +154,9 @@ CREATE TABLE works (
                   -- unlisted: reachable by direct link/share page, never listed
                   -- public:   shown in the shared Library
   cover_image_url TEXT,                   -- R2
-  created_at      INTEGER NOT NULL
+  created_at      INTEGER NOT NULL,
+  view_count      INTEGER NOT NULL DEFAULT 0  -- migration 0006; bumped by
+                                               -- POST /api/works/:id/view
 );
 
 CREATE INDEX idx_works_owner      ON works(owner_id);
@@ -176,6 +178,38 @@ CREATE TABLE work_characters (
   role         TEXT,                      -- 'protagonist','friend','villain'
   PRIMARY KEY (work_id, character_id)
 );
+```
+
+### work_reactions  (migration 0006)
+One like/dislike per (work, user). Flipping like↔dislike replaces the row
+rather than stacking a second one — `INSERT OR REPLACE` on the primary key.
+
+```sql
+CREATE TABLE work_reactions (
+  work_id    TEXT NOT NULL REFERENCES works(id) ON DELETE CASCADE,
+  user_id    TEXT NOT NULL REFERENCES users(id),
+  reaction   TEXT NOT NULL CHECK (reaction IN ('like','dislike')),
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (work_id, user_id)
+);
+```
+
+### user_events  (migration 0006)
+A lightweight signal log — one row per open/search/like — that
+`GET /api/me/recommendations` reads back to score "recommended for you"
+against a work's genre and emotions. Not a general analytics table; nothing
+else consumes it.
+
+```sql
+CREATE TABLE user_events (
+  id         TEXT PRIMARY KEY,
+  user_id    TEXT NOT NULL REFERENCES users(id),
+  kind       TEXT NOT NULL CHECK (kind IN ('open','search','like')),
+  work_id    TEXT REFERENCES works(id) ON DELETE CASCADE,  -- NULL for 'search'
+  query      TEXT,                       -- the search string, 'search' rows only
+  created_at INTEGER NOT NULL
+);
+CREATE INDEX idx_user_events_user ON user_events(user_id, created_at);
 ```
 
 **Kind rules (enforced in the app layer):**
@@ -350,6 +384,12 @@ For `kind: "story"`, `characters` may be empty and `lines` may be omitted —
 | Library: Story / Play chip | `works.kind = :k` |
 | Library: by character | join `work_characters` on `character_id` |
 | Library: sad / happy | join `work_emotions` on `emotion` |
+| Library: search | `GET /api/works?q=` — `works.title LIKE '%:q%' COLLATE NOCASE` |
+| Library: default order | no filters/`q`: top 3 by `view_count` (ties by `like_count`) pinned first, then the rest by `like_count DESC, view_count DESC, created_at DESC`; any filter/`q` present: `like_count DESC, created_at DESC` — pinning is a JS partition over one query, not a second query |
+| Views / likes / dislikes | `works.view_count`; `work_reactions` grouped by `reaction` — `POST /api/works/:id/view`, `POST /api/works/:id/reaction` |
+| Owner-only visibility change / delete | `PATCH /api/works/:id`, `DELETE /api/works/:id` — 404 if missing, 403 if signed-in user isn't `owner_id` |
+| "My stories" | `GET /api/me/works` — every work owned by the signed-in user, any visibility |
+| "Recommended for you" | `GET /api/me/recommendations` — `user_events` (kind `open`/`like`) joined back to `works`/`work_emotions` for genre/emotion overlap; falls back to most-liked public works with no signal |
 | "Hear this voice" previews | `voices.preview_audio_url` |
 | Language voice bank | voice resolution rule (§2 voices) |
 | Replay without credits | `narrations` cache hit — `GET /api/works/:id/narration` |

--- a/myproject/public/create-story.html
+++ b/myproject/public/create-story.html
@@ -53,6 +53,21 @@
             <button id="generateStoryButton">✍️ My Story</button>
         </section>
 
+        <div class="style-picker" title="Every illustration stays cartoonish — pick the flavour">
+            <label for="artStyle">🎨 Art style</label>
+            <select id="artStyle">
+                <option value="surprise">⭐ Surprise me</option>
+                <option value="storybook watercolor">Storybook watercolor</option>
+                <option value="flat vector cartoon">Flat vector cartoon</option>
+                <option value="crayon and colored-pencil">Crayon &amp; colored pencil</option>
+                <option value="paper cut-out collage">Paper cut-out collage</option>
+                <option value="claymation-style 3D">Claymation 3D</option>
+                <option value="soft pastel illustration">Soft pastel</option>
+                <option value="retro comic book">Retro comic book</option>
+                <option value="gouache children's picture book">Gouache picture book</option>
+            </select>
+        </div>
+
         <section id="take-matters-section" class="create-section" style="display:none;">
             <h2>Lisa's Story</h2>
             <div class="option-row">

--- a/myproject/public/css/style.css
+++ b/myproject/public/css/style.css
@@ -21,6 +21,13 @@ body {
     margin: 0;
     padding: 0;
     background-color: var(--bg);
+    /* Starry-night depth: a faint midnight-blue glow low on the horizon,
+       like lying in bed looking up — fixed so the sky doesn't scroll. */
+    background-image:
+        radial-gradient(ellipse 90% 55% at 50% 115%, rgba(30, 27, 75, 0.5), transparent 65%),
+        radial-gradient(ellipse 60% 40% at 15% -8%, rgba(76, 29, 149, 0.28), transparent 70%),
+        linear-gradient(180deg, #0B0918 0%, #0D0A20 50%, #0B0918 100%);
+    background-attachment: fixed;
     color: var(--text);
     line-height: 1.65;
     font-size: 17px;
@@ -665,11 +672,13 @@ main {
     border-radius: 6px;
 }
 
-/* Current word during cached-narration playback (see storyPage.js). */
+/* Current word during cached-narration playback (see storyPage.js) — a
+   warm amber "follow the bouncing ball", readable on the night background. */
 #story-content .word-active {
-    color: #fff;
-    background: rgba(139, 92, 246, 0.3);
+    color: var(--amber);
+    background: rgba(251, 191, 36, 0.14);
     border-radius: 4px;
+    box-shadow: inset 0 -2px 0 rgba(251, 191, 36, 0.55);
     transition: background-color 0.1s ease, color 0.1s ease;
 }
 
@@ -1570,4 +1579,429 @@ footer button#aboutButton:hover { color: #fff; transform: none; box-shadow: none
         padding: 24px 20px;
         text-align: center;
     }
+}
+
+/* ---------- Starry night: shooting stars + hero rocket ---------- */
+.shooting-star {
+    position: absolute;
+    top: 14%;
+    left: -8%;
+    width: 130px;
+    height: 2px;
+    border-radius: 999px;
+    background: linear-gradient(90deg, transparent, rgba(196, 181, 253, 0.9), #fff);
+    transform: rotate(12deg);
+    opacity: 0;
+    pointer-events: none;
+    animation: shoot 9s ease-in infinite;
+    animation-delay: 3s;
+    z-index: 1;
+}
+
+.shooting-star.delayed {
+    top: 38%;
+    animation-delay: 14s;
+    animation-duration: 12s;
+}
+
+@keyframes shoot {
+    0%, 91% { opacity: 0; transform: translate(0, 0) rotate(12deg); }
+    93% { opacity: 1; }
+    100% { opacity: 0; transform: translate(72vw, 15vw) rotate(12deg); }
+}
+
+.hero-rocket {
+    position: absolute;
+    width: 74px;
+    right: 15%;
+    top: 7%;
+    z-index: 1;
+    --tilt: -16deg;
+    animation: floaty-lg 9s ease-in-out infinite;
+    filter: drop-shadow(0 0 18px rgba(139, 92, 246, 0.45));
+}
+
+.hero-rocket .rocket-flame {
+    animation: twinkle 0.7s ease-in-out infinite;
+    transform-origin: 32px 78px;
+}
+
+@media (max-width: 1240px) {
+    .hero-rocket { width: 50px; right: 5%; top: 4%; opacity: 0.85; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .shooting-star { display: none; }
+    .hero-rocket,
+    .hero-rocket .rocket-flame,
+    .hero-float,
+    .header-float,
+    .star-field .star i { animation: none !important; }
+}
+
+/* ---------- Library search ---------- */
+.library-search {
+    max-width: 1140px;
+    width: 100%;
+    margin: 18px auto 6px;
+    padding: 0 24px;
+    box-sizing: border-box;
+}
+
+.library-search.hidden { display: none; }
+
+.library-search input {
+    max-width: 420px;
+    border-radius: 999px;
+    padding: 12px 20px;
+    margin-bottom: 0;
+    background-color: rgba(23, 17, 48, 0.8);
+}
+
+/* ---------- Card engagement (owner tag, views, reactions, kebab) ---------- */
+.story-card { position: relative; }
+
+.card-kebab {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    z-index: 3;
+    width: 34px;
+    height: 34px;
+    padding: 0;
+    border-radius: 50%;
+    background: rgba(11, 9, 24, 0.65);
+    border: 1px solid var(--line-strong);
+    color: var(--text);
+    font-size: 18px;
+    font-weight: 700;
+    line-height: 1;
+    box-shadow: none;
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+}
+
+.card-kebab:hover {
+    background: rgba(139, 92, 246, 0.45);
+    transform: none;
+    box-shadow: none;
+}
+
+.card-menu {
+    position: absolute;
+    top: 50px;
+    right: 10px;
+    z-index: 4;
+    min-width: 190px;
+    padding: 8px;
+    background: #171130;
+    border: 1px solid var(--line-strong);
+    border-radius: 14px;
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.6);
+    display: flex;
+    flex-direction: column;
+    animation: fadeIn 0.15s;
+}
+
+.card-menu-item {
+    width: 100%;
+    padding: 9px 12px;
+    border-radius: 10px;
+    background: none;
+    border: none;
+    box-shadow: none;
+    font: inherit;
+    font-size: 14px;
+    font-weight: 600;
+    text-align: left;
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.card-menu-item:hover {
+    background-color: var(--bg-raise);
+    color: #fff;
+    transform: none;
+    box-shadow: none;
+}
+
+.card-menu-divider { border: none; border-top: 1px solid var(--line); margin: 6px 4px; }
+
+.card-menu-danger { color: #F87171; }
+.card-menu-danger:hover { background-color: rgba(248, 113, 113, 0.12); color: #F87171; }
+
+.visibility-chip {
+    position: absolute;
+    top: 12px;
+    left: 12px;
+    z-index: 3;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: rgba(11, 9, 24, 0.75);
+    border: 1px solid var(--line-strong);
+    color: var(--lavender);
+    font-size: 12px;
+    font-weight: 700;
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+}
+
+.card-meta {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    margin: 0 0 10px;
+}
+
+.owner-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-faint);
+    min-width: 0;
+}
+
+.owner-tag-avatar {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--purple), var(--purple-deep));
+    color: #fff;
+    font-size: 11px;
+    font-weight: 700;
+}
+
+.owner-tag-avatar.owner-tag-lisa {
+    border-radius: 6px;
+    box-shadow: 0 0 10px rgba(139, 92, 246, 0.55);
+}
+
+.view-count {
+    flex-shrink: 0;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-faint);
+}
+
+.card-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.reaction-bar { display: inline-flex; gap: 6px; }
+
+.reaction-btn {
+    padding: 6px 12px;
+    border-radius: 999px;
+    background: transparent;
+    border: 1px solid var(--line);
+    color: var(--text-muted);
+    font-size: 13px;
+    font-weight: 700;
+    box-shadow: none;
+}
+
+.reaction-btn:hover {
+    border-color: rgba(196, 181, 253, 0.5);
+    color: #fff;
+    transform: none;
+    box-shadow: none;
+}
+
+.reaction-btn.active {
+    background: rgba(251, 191, 36, 0.14);
+    border-color: rgba(251, 191, 36, 0.55);
+    color: var(--amber);
+}
+
+/* Views + reactions on the story reader page */
+.engagement-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 14px 30px 0;
+}
+
+/* ---------- Create page: art style picker + caption ---------- */
+.style-picker {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    align-self: center;
+    padding: 8px 10px 8px 18px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(139, 92, 246, 0.25);
+}
+
+.style-picker label {
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--lavender);
+    white-space: nowrap;
+}
+
+.style-picker select {
+    width: auto;
+    margin-bottom: 0;
+    padding: 8px 34px 8px 14px;
+    border-radius: 999px;
+    font-size: 14px;
+    background-color: rgba(11, 9, 24, 0.6);
+}
+
+.style-caption {
+    margin: -10px 0 16px;
+    font-size: 13px;
+    font-style: italic;
+    color: var(--text-faint);
+}
+
+/* ---------- Save-to-library dialog ---------- */
+.save-dialog { width: 26em !important; }
+
+.save-dialog-lead { margin: 0 0 14px; color: var(--text-muted); }
+
+.save-options {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    text-align: left;
+}
+
+.save-option {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 13px 16px;
+    border-radius: 14px;
+    border: 1px solid var(--line);
+    background: rgba(255, 255, 255, 0.03);
+    cursor: pointer;
+    transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.save-option:hover { border-color: rgba(196, 181, 253, 0.5); }
+
+.save-option.selected {
+    border-color: var(--amber);
+    background: rgba(251, 191, 36, 0.07);
+    box-shadow: 0 0 0 1px rgba(251, 191, 36, 0.35);
+}
+
+.save-option input { display: none; }
+
+.save-option-icon { font-size: 20px; flex-shrink: 0; }
+
+.save-option-text { display: flex; flex-direction: column; gap: 2px; }
+
+.save-option-name { font-weight: 700; color: #fff; font-size: 15px; }
+
+.save-option-desc { font-size: 13px; color: var(--text-muted); }
+
+.save-dialog-confirm { color: #0B0918 !important; font-weight: 700 !important; }
+
+/* ---------- My Stories ---------- */
+.mystories-gate {
+    max-width: 440px;
+    margin: 60px auto;
+    padding: 36px 32px;
+    text-align: center;
+    border-radius: 24px;
+    background: linear-gradient(170deg, var(--bg-raise), var(--bg-raise-2));
+    border: 1px solid rgba(139, 92, 246, 0.25);
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    align-items: center;
+}
+
+.mystories-gate.hidden { display: none; }
+
+.mystories-gate p { margin: 0; color: var(--text-muted); }
+
+.gate-login {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 18px;
+    border-radius: 999px;
+    background-color: var(--bg-raise);
+    border: 1px solid var(--line-strong);
+    color: var(--text);
+    font-size: 15px;
+    font-weight: 600;
+}
+
+.gate-login:hover { background-color: var(--line-strong); color: #fff; }
+
+.mystories-controls {
+    max-width: 1140px;
+    width: 100%;
+    margin: 18px auto 0;
+    padding: 0 24px;
+    box-sizing: border-box;
+    display: flex;
+    justify-content: flex-end;
+}
+
+.mystories-controls.hidden { display: none; }
+
+.show-private-toggle {
+    padding: 9px 16px;
+    border-radius: 999px;
+    background: rgba(251, 191, 36, 0.07);
+    border: 1px solid rgba(251, 191, 36, 0.35);
+    color: var(--amber);
+    font-size: 14px;
+}
+
+.show-private-toggle input[type="checkbox"] { accent-color: var(--amber); }
+
+#my-story-list,
+.rec-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 26px;
+    align-items: stretch;
+    width: 100%;
+    max-width: 1140px;
+    margin: 10px auto 40px;
+    padding: 0 24px;
+    box-sizing: border-box;
+}
+
+.recommended-section {
+    max-width: 1140px;
+    width: 100%;
+    margin: 30px auto 0;
+    padding: 0 24px;
+    box-sizing: border-box;
+}
+
+.recommended-section.hidden { display: none; }
+
+.recommended-section h2 { margin: 0 0 6px; font-size: 26px; }
+
+.recommended-hint {
+    margin: 0 0 8px;
+    font-size: 14px;
+    color: var(--text-faint);
+}
+
+@media (max-width: 768px) {
+    #my-story-list, .rec-grid { grid-template-columns: 1fr; padding: 0 12px; }
+    .mystories-controls { justify-content: center; }
+    .hero-rocket { display: none; }
 }

--- a/myproject/public/index.html
+++ b/myproject/public/index.html
@@ -39,7 +39,24 @@
         </div>
     </header>
     <section class="hero">
-        <div class="star-field" data-stars="42" aria-hidden="true"></div>
+        <div class="star-field" data-stars="64" aria-hidden="true"></div>
+        <span class="shooting-star" aria-hidden="true"></span>
+        <span class="shooting-star delayed" aria-hidden="true"></span>
+        <svg class="hero-rocket" viewBox="0 0 64 96" aria-hidden="true">
+            <!-- flame -->
+            <path class="rocket-flame" d="M32 78 C27 85 29 92 32 96 C35 92 37 85 32 78 Z" fill="#FBBF24"/>
+            <path d="M32 80 C29.5 85 30.5 90 32 93 C33.5 90 34.5 85 32 80 Z" fill="#EC4899" opacity="0.85"/>
+            <!-- fins -->
+            <path d="M20 56 C12 62 10 72 11 78 C17 74 21 70 23 64 Z" fill="#6D28D9"/>
+            <path d="M44 56 C52 62 54 72 53 78 C47 74 43 70 41 64 Z" fill="#6D28D9"/>
+            <!-- body -->
+            <path d="M32 2 C42 14 46 30 46 44 C46 58 41 68 32 74 C23 68 18 58 18 44 C18 30 22 14 32 2 Z" fill="#C4B5FD"/>
+            <path d="M32 2 C42 14 46 30 46 44 C46 52 44.5 59 41.5 64.5 C36 60 30 52 30 40 C30 26 30.5 12 32 2 Z" fill="#8B5CF6" opacity="0.45"/>
+            <!-- window -->
+            <circle cx="32" cy="34" r="9" fill="#0B0918"/>
+            <circle cx="32" cy="34" r="6.5" fill="#171130"/>
+            <circle cx="30" cy="32" r="2" fill="#C4B5FD" opacity="0.9"/>
+        </svg>
         <img src="images/covers/story_2.webp" alt="" class="hero-float left">
         <img src="images/covers/story_10.webp" alt="" class="hero-float right">
         <img src="images/covers/story_3.webp" alt="" class="hero-float bottom-left">

--- a/myproject/public/js/auth.js
+++ b/myproject/public/js/auth.js
@@ -100,6 +100,16 @@ function buildAccountMenu(user) {
     return wrap;
 }
 
+// One shared /api/me fetch per page load — other scripts (cards, library,
+// My Stories) await window.lisaMePromise instead of refetching.
+window.lisaMePromise = fetch('/api/me')
+    .then((resp) => resp.json())
+    .then((data) => data.user || null)
+    .catch((error) => {
+        console.error('Could not load sign-in state:', error);
+        return null;
+    });
+
 // Sign-in widget for the header nav. Every page has an empty <li id="auth-nav">
 // slot; this fills it in from /api/me so signed-out visitors see "Log in"
 // and signed-in ones get an avatar + handle button that opens an account menu.
@@ -107,13 +117,22 @@ function buildAccountMenu(user) {
     const slot = document.getElementById('auth-nav');
     if (!slot) return;
 
-    let user = null;
-    try {
-        const resp = await fetch('/api/me');
-        ({ user } = await resp.json());
-    } catch (error) {
-        console.error('Could not load sign-in state:', error);
-        return;
+    const user = await window.lisaMePromise;
+
+    // Signed-in visitors get a "My Stories" tab, inserted after Create Story.
+    if (user && !document.querySelector('.nav-container nav a[href="mystories.html"]')) {
+        const createLink = document.querySelector('.nav-container nav a[href="create-story.html"]');
+        if (createLink) {
+            const li = document.createElement('li');
+            const link = document.createElement('a');
+            link.href = 'mystories.html';
+            link.textContent = 'My Stories';
+            if (window.location.pathname.split('/').pop() === 'mystories.html') {
+                link.classList.add('current-page');
+            }
+            li.appendChild(link);
+            createLink.parentElement.insertAdjacentElement('afterend', li);
+        }
     }
 
     slot.textContent = '';

--- a/myproject/public/js/cards.js
+++ b/myproject/public/js/cards.js
@@ -1,0 +1,260 @@
+// Shared story-card builder used by the Library and My Stories pages.
+// Renders one card per work row from the works API: cover, title, excerpt,
+// owner tag, view/reaction counts, and a ⋮ menu whose options grow when the
+// signed-in viewer owns the story (visibility changes, delete).
+window.LisaCards = (function () {
+    let openMenu = null;
+
+    function closeMenu() {
+        if (openMenu) {
+            openMenu.panel.remove();
+            openMenu.button.setAttribute('aria-expanded', 'false');
+            openMenu = null;
+        }
+    }
+    document.addEventListener('click', closeMenu);
+    document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeMenu(); });
+
+    function toast(title, text) {
+        if (window.Swal) {
+            Swal.fire({
+                toast: true, position: 'bottom-end', timer: 2600, showConfirmButton: false,
+                icon: 'info', title: title, text: text || '',
+                background: '#171130', color: '#EDEAF7',
+            });
+        } else {
+            alert(title + (text ? '\n' + text : ''));
+        }
+    }
+
+    // Small identity chip: LISA 1000's own stories carry the brand mark,
+    // everyone else gets an initial-avatar + handle.
+    function ownerTag(work) {
+        const tag = document.createElement('span');
+        tag.className = 'owner-tag';
+        const avatar = document.createElement('span');
+        avatar.className = 'owner-tag-avatar';
+        const isLisa = work.owner_id === 'lisa';
+        avatar.textContent = isLisa ? '✦' : (work.owner_handle || '?').charAt(0).toUpperCase();
+        if (isLisa) avatar.classList.add('owner-tag-lisa');
+        const name = document.createElement('span');
+        name.textContent = isLisa ? 'LISA 1000' : (work.owner_handle || 'guest');
+        tag.append(avatar, name);
+        return tag;
+    }
+
+    function reactionBar(work, me) {
+        const bar = document.createElement('div');
+        bar.className = 'reaction-bar';
+        const counts = { like: work.like_count || 0, dislike: work.dislike_count || 0 };
+        let mine = work.my_reaction || null;
+        const buttons = {};
+
+        function paint() {
+            for (const kind of ['like', 'dislike']) {
+                buttons[kind].textContent = `${kind === 'like' ? '👍' : '👎'} ${counts[kind]}`;
+                buttons[kind].classList.toggle('active', mine === kind);
+            }
+        }
+
+        for (const kind of ['like', 'dislike']) {
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'reaction-btn';
+            btn.setAttribute('aria-label', kind === 'like' ? 'Like this story' : 'Dislike this story');
+            btn.addEventListener('click', async (e) => {
+                e.stopPropagation();
+                if (!me) { toast('Log in to react', 'Reactions need an account.'); return; }
+                const next = mine === kind ? null : kind;
+                try {
+                    const resp = await fetch(`/api/works/${encodeURIComponent(work.id)}/reaction`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ reaction: next }),
+                    });
+                    if (resp.status === 401) { toast('Log in to react', 'Reactions need an account.'); return; }
+                    if (!resp.ok) throw new Error(`Reaction failed (${resp.status})`);
+                    const data = await resp.json();
+                    counts.like = data.like_count; counts.dislike = data.dislike_count;
+                    mine = data.my_reaction;
+                    paint();
+                } catch (error) {
+                    console.error('Could not save reaction:', error);
+                }
+            });
+            buttons[kind] = btn;
+            bar.appendChild(btn);
+        }
+        paint();
+        return bar;
+    }
+
+    function menuItem(label, onClick, danger) {
+        const item = document.createElement('button');
+        item.type = 'button';
+        item.className = 'card-menu-item' + (danger ? ' card-menu-danger' : '');
+        item.textContent = label;
+        item.addEventListener('click', (e) => { e.stopPropagation(); closeMenu(); onClick(); });
+        return item;
+    }
+
+    function kebab(work, me, card, onChanged) {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'card-kebab';
+        button.setAttribute('aria-label', 'Story options');
+        button.setAttribute('aria-haspopup', 'true');
+        button.setAttribute('aria-expanded', 'false');
+        button.textContent = '⋮';
+
+        button.addEventListener('click', (e) => {
+            e.stopPropagation();
+            if (openMenu && openMenu.button === button) { closeMenu(); return; }
+            closeMenu();
+
+            const panel = document.createElement('div');
+            panel.className = 'card-menu';
+            panel.addEventListener('click', (e2) => e2.stopPropagation());
+
+            panel.appendChild(menuItem('📖 Read', () => {
+                window.location.href = `story.html?id=${encodeURIComponent(work.id)}`;
+            }));
+            if (work.visibility === 'public' || work.visibility === 'unlisted') {
+                panel.appendChild(menuItem('🔗 Copy link', async () => {
+                    const url = `${window.location.origin}/s/${encodeURIComponent(work.id)}`;
+                    try {
+                        await navigator.clipboard.writeText(url);
+                        toast('Link copied');
+                    } catch (error) {
+                        prompt('Copy this link:', url);
+                    }
+                }));
+            }
+
+            if (me && me.id === work.owner_id) {
+                const divider = document.createElement('hr');
+                divider.className = 'card-menu-divider';
+                panel.appendChild(divider);
+
+                const visLabels = { public: '🌍 Make public', unlisted: '🔗 Make unlisted', private: '🔒 Make private' };
+                for (const vis of ['public', 'unlisted', 'private']) {
+                    if (vis === work.visibility) continue;
+                    panel.appendChild(menuItem(visLabels[vis], async () => {
+                        try {
+                            const resp = await fetch(`/api/works/${encodeURIComponent(work.id)}`, {
+                                method: 'PATCH',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify({ visibility: vis }),
+                            });
+                            if (!resp.ok) throw new Error(`Update failed (${resp.status})`);
+                            work.visibility = vis;
+                            toast('Visibility updated', `This story is now ${vis}.`);
+                            if (onChanged) onChanged('visibility', work);
+                        } catch (error) {
+                            console.error('Could not change visibility:', error);
+                            toast('Could not update', 'Please try again.');
+                        }
+                    }));
+                }
+
+                panel.appendChild(menuItem('🗑 Delete story', async () => {
+                    if (!confirm(`Delete "${work.title}" forever? This cannot be undone.`)) return;
+                    try {
+                        const resp = await fetch(`/api/works/${encodeURIComponent(work.id)}`, { method: 'DELETE' });
+                        if (!resp.ok) throw new Error(`Delete failed (${resp.status})`);
+                        card.remove();
+                        toast('Story deleted');
+                        if (onChanged) onChanged('deleted', work);
+                    } catch (error) {
+                        console.error('Could not delete story:', error);
+                        toast('Could not delete', 'Please try again.');
+                    }
+                }, true));
+            }
+
+            button.parentElement.appendChild(panel);
+            button.setAttribute('aria-expanded', 'true');
+            openMenu = { button, panel };
+        });
+        return button;
+    }
+
+    // work: a row from GET /api/works (or a minimal {title, cover_image_url,
+    // excerpt} object from the stories.json fallback — no id means no
+    // engagement UI). opts: { me, onChanged, badge }.
+    function buildWorkCard(container, work, opts) {
+        const { me = null, onChanged = null, badge = false } = opts || {};
+        const card = document.createElement('div');
+        card.className = 'story-card story-card-link';
+        const href = work.id
+            ? `story.html?id=${encodeURIComponent(work.id)}`
+            : `story.html?sid=${work.sid}`;
+        card.addEventListener('click', () => { window.location.href = href; });
+
+        const frame = document.createElement('div');
+        frame.className = 'cover-frame card-cover';
+        const coverBg = document.createElement('img');
+        coverBg.className = 'cover-frame-bg';
+        coverBg.src = work.cover_image_url || '';
+        coverBg.alt = '';
+        coverBg.setAttribute('aria-hidden', 'true');
+        coverBg.loading = 'lazy';
+        const cover = document.createElement('img');
+        cover.className = 'cover-frame-fg';
+        cover.src = work.cover_image_url || '';
+        cover.alt = `${work.title} cover`;
+        cover.loading = 'lazy';
+        cover.onerror = function () {
+            const placeholder = document.createElement('div');
+            placeholder.className = 'cover-placeholder';
+            placeholder.textContent = (work.title || '?').charAt(0);
+            frame.replaceWith(placeholder);
+        };
+        frame.append(coverBg, cover);
+        card.appendChild(frame);
+
+        if (work.id) card.appendChild(kebab(work, me, card, onChanged));
+        if (badge && work.visibility && work.visibility !== 'public') {
+            const chip = document.createElement('span');
+            chip.className = 'visibility-chip';
+            chip.textContent = work.visibility === 'private' ? '🔒 Private' : '🔗 Unlisted';
+            card.appendChild(chip);
+        }
+
+        const body = document.createElement('div');
+        body.className = 'card-body';
+
+        const heading = document.createElement('h2');
+        heading.textContent = work.title;
+        body.appendChild(heading);
+
+        if (work.id) {
+            const meta = document.createElement('div');
+            meta.className = 'card-meta';
+            meta.appendChild(ownerTag(work));
+            const views = document.createElement('span');
+            views.className = 'view-count';
+            views.textContent = `👁 ${work.view_count || 0}`;
+            meta.appendChild(views);
+            body.appendChild(meta);
+        }
+
+        const text = document.createElement('p');
+        text.textContent = (work.excerpt || '').substring(0, 150) + '...';
+        body.appendChild(text);
+
+        const footer = document.createElement('div');
+        footer.className = 'card-footer';
+        const button = document.createElement('button');
+        button.textContent = 'Read More →';
+        footer.appendChild(button);
+        if (work.id) footer.appendChild(reactionBar(work, me));
+        body.appendChild(footer);
+
+        card.appendChild(body);
+        container.appendChild(card);
+        return card;
+    }
+
+    return { buildWorkCard: buildWorkCard };
+})();

--- a/myproject/public/js/createStory.js
+++ b/myproject/public/js/createStory.js
@@ -50,6 +50,13 @@ document.addEventListener('DOMContentLoaded', function() {
 // Why the last generation failed, for the error card shown to the user.
 let lastGenerationError = '';
 
+// The cartoon style sent with every generation; the server enforces the
+// no-photorealism suffix regardless. 'surprise' lets the server pick.
+function selectedArtStyle() {
+    const picker = document.getElementById('artStyle');
+    return picker ? picker.value : 'surprise';
+}
+
 async function generateStory(prompt) {
     console.log('Contacting story server with prompt:', prompt); // Debugging code
     lastGenerationError = '';
@@ -64,7 +71,7 @@ async function generateStory(prompt) {
                 headers: {
                     'Content-Type': 'application/json'
                 },
-                body: JSON.stringify({ prompt: prompt })
+                body: JSON.stringify({ prompt: prompt, style: selectedArtStyle() })
             });
 
             if (!response.ok) {
@@ -235,19 +242,43 @@ document.addEventListener('DOMContentLoaded', function() {
 
         let visibility = 'public';
         if (window.Swal) {
+            // Tactile option cards instead of bare radios — each choice is a
+            // full-width card with an icon, a name, and what it means.
+            const options = [
+                { value: 'public', icon: '🌍', name: 'Public', desc: 'Everyone can find it in the Library' },
+                { value: 'unlisted', icon: '🔗', name: 'Unlisted', desc: 'Only people with the link can read it' },
+                { value: 'private', icon: '🔒', name: 'Private', desc: 'Only you — it lives in My Stories' },
+            ];
+            const cardsHtml = options.map((o, i) => `
+                <label class="save-option${i === 0 ? ' selected' : ''}">
+                    <input type="radio" name="save-visibility" value="${o.value}"${i === 0 ? ' checked' : ''}>
+                    <span class="save-option-icon">${o.icon}</span>
+                    <span class="save-option-text">
+                        <span class="save-option-name">${o.name}</span>
+                        <span class="save-option-desc">${o.desc}</span>
+                    </span>
+                </label>`).join('');
             const choice = await Swal.fire({
                 title: 'Save to Library',
-                text: 'Who should see this story?',
-                input: 'radio',
-                inputOptions: {
-                    public: '🌍 Everyone',
-                    unlisted: '🔗 Only people with the link',
-                    private: '🔒 Private (only you)',
-                },
-                inputValue: 'public',
+                html: `<p class="save-dialog-lead">Where should “${(currentStory.title || 'your story').replace(/</g, '&lt;')}” live?</p>
+                       <div class="save-options">${cardsHtml}</div>`,
                 showCancelButton: true,
-                confirmButtonText: 'Save',
-                confirmButtonColor: '#8B5CF6',
+                confirmButtonText: '✨ Save story',
+                cancelButtonText: 'Not yet',
+                confirmButtonColor: '#FBBF24',
+                customClass: { popup: 'save-dialog', confirmButton: 'save-dialog-confirm' },
+                background: '#171130',
+                color: '#EDEAF7',
+                didOpen: (popup) => {
+                    popup.querySelectorAll('.save-option').forEach((label) => {
+                        label.addEventListener('click', () => {
+                            popup.querySelectorAll('.save-option').forEach((l) => l.classList.remove('selected'));
+                            label.classList.add('selected');
+                        });
+                    });
+                },
+                preConfirm: () =>
+                    document.querySelector('input[name="save-visibility"]:checked')?.value || 'public',
             });
             if (!choice.isConfirmed) return;
             visibility = choice.value || 'public';
@@ -336,7 +367,7 @@ document.addEventListener('DOMContentLoaded', function() {
         };
     }
 
-    function displayStory(story, imageUrl, title = 'Generated Story') {
+    function displayStory(story, imageUrl, title = 'Generated Story', styleUsed = null) {
         if (!story) {
             storyContainer.classList.add('generated-story');
             storyContainer.innerHTML = `
@@ -349,6 +380,7 @@ document.addEventListener('DOMContentLoaded', function() {
         storyContainer.innerHTML = `
             <h2>${title}</h2>
             <img src="${imageUrl}" alt="Generated Image" class="generated-image">
+            ${styleUsed ? `<p class="style-caption">🎨 Illustrated in: ${styleUsed}</p>` : ''}
             <p id="story-content">${story}</p>`;
         storyContainer.classList.add('generated-story');
         storyContainer.style.transition = 'opacity 0.5s ease';
@@ -385,7 +417,7 @@ document.addEventListener('DOMContentLoaded', function() {
         stopLoading();
         if (storyData) {
             const storyTitle = storyData.title || `Generated ${randomGenre} Story`;
-            displayStory(storyData.story, storyData.imageUrl, storyTitle);
+            displayStory(storyData.story, storyData.imageUrl, storyTitle, storyData.styleUsed);
             currentNarration = storyData.narration || null;
             setCurrentStory(storyTitle, randomGenre, 'en', storyData);
             buttonContainer.style.display = 'flex';
@@ -413,7 +445,7 @@ document.addEventListener('DOMContentLoaded', function() {
         stopLoading();
         if (storyData) {
             const storyTitle = storyData.title || `Generated ${genre} Story`;
-            displayStory(storyData.story, storyData.imageUrl, storyTitle);
+            displayStory(storyData.story, storyData.imageUrl, storyTitle, storyData.styleUsed);
             currentNarration = storyData.narration || null;
             setCurrentStory(storyTitle, genre, 'en', storyData);
             buttonContainer.style.display = 'flex';
@@ -444,7 +476,7 @@ document.addEventListener('DOMContentLoaded', function() {
         stopLoading();
         if (storyData) {
             const storyTitle = title.trim() || storyData.title || 'My Story';
-            displayStory(storyData.story, storyData.imageUrl, storyTitle);
+            displayStory(storyData.story, storyData.imageUrl, storyTitle, storyData.styleUsed);
             currentNarration = storyData.narration || null;
             setCurrentStory(storyTitle, theme, outputLanguage, storyData);
             buttonContainer.style.display = 'flex';

--- a/myproject/public/js/loadStories.js
+++ b/myproject/public/js/loadStories.js
@@ -1,76 +1,26 @@
-// Build one library card. Clicking anywhere on it (or the Read button)
-// opens the story's own reader page.
-function buildStoryCard(mainElement, { title, image, excerpt, href }) {
-    const card = document.createElement('div');
-    card.className = 'story-card story-card-link';
-    card.addEventListener('click', () => { window.location.href = href; });
+// Card rendering lives in js/cards.js (LisaCards.buildWorkCard) — shared
+// with the My Stories page so both grids stay identical.
 
-    // Cover artwork, never cropped: letterboxed in a 16:9 frame whose sides
-    // are a blurred copy of the same image. Lettered placeholder if missing.
-    const frame = document.createElement('div');
-    frame.className = 'cover-frame card-cover';
-
-    const coverBg = document.createElement('img');
-    coverBg.className = 'cover-frame-bg';
-    coverBg.src = image || '';
-    coverBg.alt = '';
-    coverBg.setAttribute('aria-hidden', 'true');
-    coverBg.loading = 'lazy';
-
-    const cover = document.createElement('img');
-    cover.className = 'cover-frame-fg';
-    cover.src = image || '';
-    cover.alt = `${title} cover`;
-    cover.loading = 'lazy';
-    cover.onerror = function() {
-        const placeholder = document.createElement('div');
-        placeholder.className = 'cover-placeholder';
-        placeholder.textContent = title.charAt(0);
-        frame.replaceWith(placeholder);
-    };
-
-    frame.appendChild(coverBg);
-    frame.appendChild(cover);
-    card.appendChild(frame);
-
-    const body = document.createElement('div');
-    body.className = 'card-body';
-
-    const heading = document.createElement('h2');
-    heading.textContent = title;
-
-    const text = document.createElement('p');
-    text.textContent = excerpt.substring(0, 150) + '...';
-
-    const button = document.createElement('button');
-    button.textContent = 'Read More →';
-
-    body.appendChild(heading);
-    body.appendChild(text);
-    body.appendChild(button);
-    card.appendChild(body);
-    mainElement.appendChild(card);
-}
+// Signed-in viewer (or null), shared from auth.js — gates reactions and
+// unlocks the owner options in each card's ⋮ menu.
+let libraryMe = null;
 
 function renderWorks(mainElement, works) {
     mainElement.innerHTML = '';
     if (!works.length) {
         const empty = document.createElement('p');
         empty.className = 'library-empty';
-        empty.textContent = 'No stories match these filters — try widening them.';
+        empty.textContent = libraryFilters.q
+            ? `No stories found for “${libraryFilters.q}” — try another search.`
+            : 'No stories match these filters — try widening them.';
         mainElement.appendChild(empty);
         return;
     }
-    works.forEach(work => buildStoryCard(mainElement, {
-        title: work.title,
-        image: work.cover_image_url,
-        excerpt: work.excerpt || '',
-        href: `story.html?id=${encodeURIComponent(work.id)}`,
-    }));
+    works.forEach(work => LisaCards.buildWorkCard(mainElement, work, { me: libraryMe }));
 }
 
 // Active filter state; empty string = "All" for that group.
-const libraryFilters = { owner: '', kind: '', genre: '', emotion: '' };
+const libraryFilters = { owner: '', kind: '', genre: '', emotion: '', q: '' };
 
 async function fetchWorks() {
     const params = new URLSearchParams();
@@ -114,11 +64,31 @@ function activateFilterBar(mainElement) {
     });
 }
 
+// Debounced title search — refetches the library as the visitor types.
+function activateSearch(mainElement) {
+    const input = document.getElementById('librarySearch');
+    if (!input) return;
+    input.parentElement.classList.remove('hidden');
+    let timer = null;
+    input.addEventListener('input', () => {
+        clearTimeout(timer);
+        timer = setTimeout(async () => {
+            libraryFilters.q = input.value.trim();
+            try {
+                renderWorks(mainElement, await fetchWorks());
+            } catch (error) {
+                console.error('Error searching stories:', error);
+            }
+        }, 300);
+    });
+}
+
 // Works API (D1) first; stories.json as fallback for environments without
 // a database (local Express dev, static preview). Filters only appear in
 // API mode — the flat JSON has no genre/emotion data to filter on.
 async function loadLibrary() {
     const mainElement = document.getElementById('story-list');
+    libraryMe = window.lisaMePromise ? await window.lisaMePromise : null;
 
     try {
         const works = await fetchWorks();
@@ -126,6 +96,7 @@ async function loadLibrary() {
             renderWorks(mainElement, works);
             buildGenreChips(works);
             activateFilterBar(mainElement);
+            activateSearch(mainElement);
             return;
         }
     } catch (error) {
@@ -133,12 +104,12 @@ async function loadLibrary() {
     }
 
     const stories = await fetch('data/stories.json').then(r => r.json());
-    stories.sort((a, b) => a.id - b.id).forEach(story => buildStoryCard(mainElement, {
+    stories.sort((a, b) => a.id - b.id).forEach(story => LisaCards.buildWorkCard(mainElement, {
         title: story.title,
-        image: story.image,
+        cover_image_url: story.image,
         excerpt: story.content,
-        href: `story.html?sid=${story.id}`,
-    }));
+        sid: story.id,
+    }, {}));
 }
 
 document.addEventListener('DOMContentLoaded', function() {

--- a/myproject/public/js/myStories.js
+++ b/myproject/public/js/myStories.js
@@ -1,0 +1,90 @@
+// My Stories — the signed-in user's shelf. Private stories stay hidden
+// until the "Show private stories" checkbox is ticked; a recommendations
+// rail (built from opens, searches, and likes) sits underneath.
+(function () {
+    let me = null;
+    let myWorks = [];
+
+    function renderMine() {
+        const grid = document.getElementById('my-story-list');
+        const showPrivate = document.getElementById('showPrivate').checked;
+        grid.innerHTML = '';
+
+        const visible = myWorks.filter((w) => showPrivate || w.visibility !== 'private');
+        if (!visible.length) {
+            const empty = document.createElement('p');
+            empty.className = 'library-empty';
+            empty.textContent = myWorks.length
+                ? 'All your stories here are private — tick “Show private stories” to see them.'
+                : "You haven't saved any stories yet — create one and it will appear here.";
+            grid.appendChild(empty);
+            return;
+        }
+        visible.forEach((work) =>
+            LisaCards.buildWorkCard(grid, work, {
+                me: me,
+                badge: true,
+                onChanged: (kind, changed) => {
+                    if (kind === 'deleted') {
+                        myWorks = myWorks.filter((w) => w.id !== changed.id);
+                        renderMine();
+                    }
+                    if (kind === 'visibility') renderMine();
+                },
+            })
+        );
+    }
+
+    async function loadRecommendations() {
+        try {
+            const resp = await fetch('/api/me/recommendations');
+            if (!resp.ok) return;
+            const { works } = await resp.json();
+            if (!works || !works.length) return;
+            const section = document.getElementById('recommended-section');
+            const grid = document.getElementById('rec-list');
+            section.classList.remove('hidden');
+            works.forEach((work) => LisaCards.buildWorkCard(grid, work, { me: me }));
+        } catch (error) {
+            console.warn('Recommendations unavailable:', error);
+        }
+    }
+
+    async function init() {
+        me = window.lisaMePromise ? await window.lisaMePromise : null;
+
+        if (!me) {
+            document.getElementById('mystories-gate').classList.remove('hidden');
+            return;
+        }
+
+        document.getElementById('mystories-controls').classList.remove('hidden');
+        document.getElementById('showPrivate').addEventListener('change', renderMine);
+
+        try {
+            const resp = await fetch('/api/me/works');
+            if (!resp.ok) throw new Error(`My works API ${resp.status}`);
+            ({ works: myWorks = [] } = await resp.json());
+        } catch (error) {
+            console.error('Could not load your stories:', error);
+            myWorks = [];
+        }
+        renderMine();
+        loadRecommendations();
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        init().catch((error) => console.error('My Stories failed to load:', error));
+
+        // Nav plumbing shared with the other pages (language + translate toggle)
+        const nativeLanguage = document.getElementById('nativeLanguage');
+        const otherLanguageInput = document.getElementById('otherLanguage');
+        nativeLanguage.addEventListener('change', function () {
+            otherLanguageInput.classList.toggle('hidden', this.value !== 'other');
+            if (this.value === 'other') otherLanguageInput.focus();
+        });
+        document.getElementById('translation-toggle').addEventListener('click', function () {
+            this.classList.toggle('active');
+        });
+    });
+})();

--- a/myproject/public/js/script.js
+++ b/myproject/public/js/script.js
@@ -45,8 +45,9 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 
-    // Load initial story on page load
-    fetchAndDisplayStory(1);
+    // Load initial story on page load ("Sue's Thoughtful Act" — Spot was
+    // retired from the homepage by request)
+    fetchAndDisplayStory(4);
 });
 
 const messages = [

--- a/myproject/public/js/storyPage.js
+++ b/myproject/public/js/storyPage.js
@@ -31,6 +31,10 @@ async function fetchStory() {
                     narration: (work.scenes || []).map((s) => s.narration_text || s.display_text).join('\n'),
                     language: work.language || 'en',
                     visibility: work.visibility,
+                    view_count: work.view_count || 0,
+                    like_count: work.like_count || 0,
+                    dislike_count: work.dislike_count || 0,
+                    my_reaction: work.my_reaction || null,
                 };
             }
         } catch (error) {
@@ -98,6 +102,71 @@ async function renderStory() {
         coverWrapEl.classList.remove('hidden');
         coverEl.onerror = () => coverWrapEl.classList.add('hidden');
     }
+
+    if (story.id) {
+        buildEngagementRow(story, titleEl);
+        // Count the open (fire-and-forget) and reflect the fresh total.
+        fetch(`/api/works/${encodeURIComponent(story.id)}/view`, { method: 'POST' })
+            .then((r) => (r.ok ? r.json() : null))
+            .then((data) => {
+                const el = document.getElementById('story-view-count');
+                if (data && el) el.textContent = `👁 ${data.view_count}`;
+            })
+            .catch(() => {});
+    }
+}
+
+// Views + like/dislike, rendered directly under the story title.
+function buildEngagementRow(story, titleEl) {
+    const row = document.createElement('div');
+    row.className = 'engagement-row';
+
+    const views = document.createElement('span');
+    views.id = 'story-view-count';
+    views.className = 'view-count';
+    views.textContent = `👁 ${story.view_count}`;
+    row.appendChild(views);
+
+    const counts = { like: story.like_count, dislike: story.dislike_count };
+    let mine = story.my_reaction;
+    const buttons = {};
+    const paint = () => {
+        for (const kind of ['like', 'dislike']) {
+            buttons[kind].textContent = `${kind === 'like' ? '👍' : '👎'} ${counts[kind]}`;
+            buttons[kind].classList.toggle('active', mine === kind);
+        }
+    };
+    for (const kind of ['like', 'dislike']) {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'reaction-btn';
+        btn.addEventListener('click', async () => {
+            const next = mine === kind ? null : kind;
+            try {
+                const resp = await fetch(`/api/works/${encodeURIComponent(story.id)}/reaction`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ reaction: next }),
+                });
+                if (resp.status === 401) {
+                    notifyUser('Log in to react', 'Reactions need an account — use the Log in button in the menu.');
+                    return;
+                }
+                if (!resp.ok) throw new Error(`Reaction failed (${resp.status})`);
+                const data = await resp.json();
+                counts.like = data.like_count;
+                counts.dislike = data.dislike_count;
+                mine = data.my_reaction;
+                paint();
+            } catch (error) {
+                console.error('Could not save reaction:', error);
+            }
+        });
+        buttons[kind] = btn;
+        row.appendChild(btn);
+    }
+    paint();
+    titleEl.insertAdjacentElement('afterend', row);
 }
 
 // ---------- Narration cache + word highlighting (saved works only) ----------

--- a/myproject/public/mystories.html
+++ b/myproject/public/mystories.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Library · Lisa 1000</title>
+    <title>My Stories · Lisa 1000</title>
     <link rel="stylesheet" href="css/style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Young+Serif&family=Karla:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -39,64 +39,51 @@
         </div>
         <div class="page-header">
             <div class="star-field" data-stars="22" aria-hidden="true"></div>
-            <img src="images/covers/story_4.webp" alt="" class="header-float left">
-            <img src="images/covers/story_9.webp" alt="" class="header-float right">
             <div class="page-header-inner">
-                <h1>The Library</h1>
-                <p>Every story, beautifully illustrated — pick one and start reading.</p>
+                <h1>My Stories</h1>
+                <p>Everything you've made, and stories we think you'll love next.</p>
             </div>
         </div>
     </header>
 
-    <div class="library-search hidden">
-        <input type="search" id="librarySearch" placeholder="🔍 Search stories…" autocomplete="off" aria-label="Search stories by title">
-    </div>
-
-    <section id="library-filters" class="filter-bar hidden" aria-label="Filter stories">
-        <div class="filter-group" data-param="owner">
-            <span class="filter-label">Who</span>
-            <button class="chip active" data-value="">All</button>
-            <button class="chip" data-value="lisa">✦ Lisa's</button>
-            <button class="chip" data-value="guest">Community</button>
-        </div>
-        <div class="filter-group" data-param="kind">
-            <span class="filter-label">Type</span>
-            <button class="chip active" data-value="">All</button>
-            <button class="chip" data-value="story">📖 Stories</button>
-            <button class="chip" data-value="play">🎭 Plays</button>
-        </div>
-        <div class="filter-group" data-param="genre">
-            <span class="filter-label">Genre</span>
-            <button class="chip active" data-value="">All</button>
-            <!-- genre chips are filled in from the loaded works -->
-        </div>
-        <div class="filter-group" data-param="emotion">
-            <span class="filter-label">Mood</span>
-            <button class="chip active" data-value="">All</button>
-            <button class="chip" data-value="happy">😊 Happy</button>
-            <button class="chip" data-value="sad">😢 Sad</button>
-            <button class="chip" data-value="inspired">🌟 Inspired</button>
-            <button class="chip" data-value="cozy">🕯️ Cozy</button>
-            <button class="chip" data-value="funny">😄 Funny</button>
-            <button class="chip" data-value="excited">⚡ Excited</button>
-        </div>
+    <!-- Shown only to logged-out visitors -->
+    <section id="mystories-gate" class="mystories-gate hidden">
+        <p>My Stories is your personal shelf — log in to see the stories you've made.</p>
+        <a href="/auth/login?next=/mystories.html" class="auth-google-btn gate-login">
+            <svg width="18" height="18" viewBox="0 0 48 48" aria-hidden="true"><path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/><path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"/><path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"/><path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"/></svg>
+            <span>Log in</span>
+        </a>
     </section>
 
-    <main id="story-list">
-        <!-- Stories will be loaded here dynamically -->
+    <section id="mystories-controls" class="mystories-controls hidden">
+        <label class="checkbox-row show-private-toggle">
+            <input type="checkbox" id="showPrivate">
+            <span>🔒 Show private stories</span>
+        </label>
+    </section>
+
+    <main id="my-story-list">
+        <!-- Your stories are loaded here -->
     </main>
+
+    <section id="recommended-section" class="recommended-section hidden">
+        <h2>✨ Recommended for you</h2>
+        <p class="recommended-hint">Picked from what you've opened, searched, and liked.</p>
+        <div id="rec-list" class="rec-grid"></div>
+    </section>
+
     <footer>
         <span class="footer-brand">✦ LISA 1000</span>
         <div class="footer-links">
             <button id="aboutButton">About Us</button>
             <a href="index.html">Home</a>
-            <a href="create-story.html">Create story</a>
+            <a href="library.html">Library</a>
         </div>
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
     <script src="js/stars.js"></script>
     <script src="js/auth.js"></script>
     <script src="js/cards.js"></script>
-    <script src="js/loadStories.js"></script>
+    <script src="js/myStories.js"></script>
 </body>
 </html>

--- a/myproject/worker/index.js
+++ b/myproject/worker/index.js
@@ -19,6 +19,24 @@ const OPENAI_TEXT_MODEL = 'gpt-5-mini';
 const CLAUDE_MODEL = 'claude-sonnet-5'; // swap to 'claude-haiku-4-5' (cheaper) or 'claude-opus-4-8' (higher quality)
 const HIGGSFIELD_BASE = 'https://platform.higgsfield.ai';
 
+// Style palette for generated illustrations. Every image prompt is wrapped
+// with one of these plus CARTOON_SUFFIX below, so covers stay unmistakably
+// storybook art — never photoreal — no matter which style the user picks.
+const CARTOON_STYLES = [
+    'storybook watercolor',
+    'flat vector cartoon',
+    'crayon and colored-pencil',
+    'paper cut-out collage',
+    'claymation-style 3D',
+    'soft pastel illustration',
+    'retro comic book',
+    "gouache children's picture book",
+];
+const DEFAULT_CARTOON_STYLE = 'storybook watercolor';
+// Hard suffix appended to every image prompt regardless of style, provider,
+// or user input — the one non-negotiable guardrail for a kids' product.
+const CARTOON_SUFFIX = ", charming children's cartoon illustration, absolutely no photorealism, no real people";
+
 function json(data, status = 200) {
     return new Response(JSON.stringify(data), {
         status,
@@ -396,6 +414,25 @@ async function generateIllustrationOpenAI(env, prompt) {
     return `data:image/png;base64,${b64}`;
 }
 
+// Poll a submitted Higgsfield job to completion. Shared by every
+// text2image model — submission bodies differ, polling doesn't.
+async function pollHiggsfieldJob(auth, job) {
+    const deadline = Date.now() + 120000;
+    while (!['completed', 'failed', 'nsfw'].includes(job.status)) {
+        if (Date.now() > deadline) throw new Error('Higgsfield polling timed out');
+        await new Promise((r) => setTimeout(r, 2000));
+        const poll = await fetch(`${HIGGSFIELD_BASE}/requests/${job.request_id}/status`, { headers: auth });
+        if (poll.status >= 500) continue; // transient server error, keep polling
+        if (!poll.ok) throw new Error(`Higgsfield poll failed (${poll.status})`);
+        job = await poll.json();
+    }
+
+    if (job.status !== 'completed' || !job.images?.length) {
+        throw new Error(`Higgsfield image generation ${job.status}`);
+    }
+    return job.images[0].url;
+}
+
 // Higgsfield Soul text-to-image via REST: submit, then poll to completion.
 // Kept for when HF_CREDENTIALS (platform.higgsfield.ai developer keys) are set up.
 async function generateIllustration(env, prompt) {
@@ -415,22 +452,64 @@ async function generateIllustration(env, prompt) {
     if (!submit.ok) {
         throw new Error(`Higgsfield submit failed (${submit.status}): ${await submit.text()}`);
     }
+    return pollHiggsfieldJob(auth, await submit.json());
+}
 
-    let job = await submit.json();
-    const deadline = Date.now() + 120000;
-    while (!['completed', 'failed', 'nsfw'].includes(job.status)) {
-        if (Date.now() > deadline) throw new Error('Higgsfield polling timed out');
-        await new Promise((r) => setTimeout(r, 2000));
-        const poll = await fetch(`${HIGGSFIELD_BASE}/requests/${job.request_id}/status`, { headers: auth });
-        if (poll.status >= 500) continue; // transient server error, keep polling
-        if (!poll.ok) throw new Error(`Higgsfield poll failed (${poll.status})`);
-        job = await poll.json();
-    }
+// Higgsfield Recraft V4.1 text-to-image — the model the user's own
+// Higgsfield account used to generate the original covers, at 16:9 1344x768.
+// NOTE: /v1/text2image/soul is confirmed (it's the working code above); the
+// analogous /v1/text2image/recraft path and body below follow the same
+// submit+poll contract by inference from the Soul route and the Higgsfield
+// SDK/CLI docs (which name the recraft_v4_1 model but don't publish its REST
+// path). Confirm the exact route/params against cloud.higgsfield.ai on the
+// first live call.
+async function generateIllustrationHiggsfield(env, prompt, opts = {}) {
+    const auth = { 'Authorization': `Key ${env.HF_CREDENTIALS}`, 'Content-Type': 'application/json' };
 
-    if (job.status !== 'completed' || !job.images?.length) {
-        throw new Error(`Higgsfield image generation ${job.status}`);
+    const submit = await fetch(`${HIGGSFIELD_BASE}/v1/text2image/recraft`, {
+        method: 'POST',
+        headers: auth,
+        body: JSON.stringify({
+            prompt,
+            model: 'recraft_v4_1',
+            width_and_height: opts.widthAndHeight || '1344x768',
+            batch_size: 1,
+        }),
+    });
+    if (!submit.ok) {
+        throw new Error(`Higgsfield recraft submit failed (${submit.status}): ${await submit.text()}`);
     }
-    return job.images[0].url;
+    return pollHiggsfieldJob(auth, await submit.json());
+}
+
+// Resolve the requested style: a literal CARTOON_STYLES entry, 'surprise'
+// for a random pick, or the default when omitted/unrecognized.
+function resolveCartoonStyle(requested) {
+    if (requested === 'surprise') {
+        return CARTOON_STYLES[Math.floor(Math.random() * CARTOON_STYLES.length)];
+    }
+    return CARTOON_STYLES.includes(requested) ? requested : DEFAULT_CARTOON_STYLE;
+}
+
+// Wrap a base image prompt with its style prefix and the hard suffix.
+// Applies identically no matter which provider ends up serving the request.
+function applyCartoonStyle(prompt, style) {
+    return `${style}, ${prompt}${CARTOON_SUFFIX}`;
+}
+
+// Cover chain: Higgsfield recraft_v4_1 first (when HF_CREDENTIALS is
+// configured — it's the model that made the original covers), OpenAI
+// gpt-image-2 otherwise or on any Higgsfield failure. Plain sequential
+// try/catch, same shape as the file's other provider fallbacks.
+async function generateCoverImage(env, styledPrompt) {
+    if (env.HF_CREDENTIALS) {
+        try {
+            return await generateIllustrationHiggsfield(env, styledPrompt);
+        } catch (error) {
+            console.error('Higgsfield cover generation failed, falling back to OpenAI:', error.message);
+        }
+    }
+    return await generateIllustrationOpenAI(env, styledPrompt);
 }
 
 const STORY_SYSTEM_PROMPT =
@@ -481,13 +560,42 @@ async function handleGenerateStory(env, anthropic, body) {
 
     const { title, story, narration, imagePrompt } = parseStoryParts(text);
 
-    const imageUrl = await generateIllustrationOpenAI(env, (imagePrompt || story).substring(0, 1000));
-    return json({ title, story, narration, imageUrl });
+    const styleUsed = resolveCartoonStyle(body.style);
+    const styledPrompt = applyCartoonStyle((imagePrompt || story).substring(0, 1000), styleUsed);
+    const imageUrl = await generateCoverImage(env, styledPrompt);
+    return json({ title, story, narration, imageUrl, styleUsed });
 }
 
 // ---------- Works API (D1 — schema in docs/SCHEMA.md) ----------
 
-// GET /api/works?kind=&genre=&owner=&emotion=&character=
+// Shared SELECT fragment for every listing-shaped work row (library, a
+// user's own works, recommendations): engagement counts, the owner's
+// handle, and — when signed in — the viewer's own reaction. IMPORTANT: the
+// `?` inside my_reaction's subselect is the FIRST placeholder in any query
+// built from this fragment (it sits in the SELECT clause, before any WHERE
+// binds), so callers must bind sessionUser.id first when sessionUser is set.
+function workListColumnsSql(sessionUser) {
+    return `w.id, w.kind, w.title, w.genre, w.language, w.length, w.owner_id,
+            w.visibility, w.cover_image_url, w.created_at, w.view_count,
+            (SELECT s.display_text FROM scenes s
+             WHERE s.work_id = w.id ORDER BY s.idx LIMIT 1) AS excerpt,
+            (SELECT GROUP_CONCAT(we.emotion) FROM work_emotions we
+             WHERE we.work_id = w.id) AS emotions,
+            (SELECT COUNT(*) FROM work_reactions wr WHERE wr.work_id = w.id AND wr.reaction = 'like') AS like_count,
+            (SELECT COUNT(*) FROM work_reactions wr WHERE wr.work_id = w.id AND wr.reaction = 'dislike') AS dislike_count,
+            u.handle AS owner_handle,
+            ${sessionUser
+                ? '(SELECT reaction FROM work_reactions wr WHERE wr.work_id = w.id AND wr.user_id = ?) AS my_reaction'
+                : 'NULL AS my_reaction'}`;
+}
+
+// Every row selected via workListColumnsSql() needs its comma-joined
+// emotions string exploded into an array.
+function mapWorkRow(r) {
+    return { ...r, emotions: r.emotions ? r.emotions.split(',') : [] };
+}
+
+// GET /api/works?kind=&genre=&owner=&emotion=&character=&q=
 // Library listing with every filter from the schema's feature->query map.
 async function handleListWorks(env, url, sessionUser) {
     if (!env.DB) return json({ error: 'Database not configured' }, 501);
@@ -498,37 +606,243 @@ async function handleListWorks(env, url, sessionUser) {
     // never listed; 'private' never leaves the DB except to its owner.
     const where = sessionUser ? ["(w.visibility = 'public' OR w.owner_id = ?)"] : ["w.visibility = 'public'"];
     const binds = sessionUser ? [sessionUser.id] : [];
+    let hasFilter = false;
 
-    if (p.get('kind'))  { where.push('w.kind = ?');     binds.push(p.get('kind')); }
-    if (p.get('genre')) { where.push('w.genre = ?');    binds.push(p.get('genre')); }
-    if (p.get('owner')) { where.push('w.owner_id = ?'); binds.push(p.get('owner')); }
+    if (p.get('kind'))  { where.push('w.kind = ?');     binds.push(p.get('kind')); hasFilter = true; }
+    if (p.get('genre')) { where.push('w.genre = ?');    binds.push(p.get('genre')); hasFilter = true; }
+    if (p.get('owner')) { where.push('w.owner_id = ?'); binds.push(p.get('owner')); hasFilter = true; }
     if (p.get('emotion')) {
         where.push('EXISTS (SELECT 1 FROM work_emotions we WHERE we.work_id = w.id AND we.emotion = ?)');
         binds.push(p.get('emotion'));
+        hasFilter = true;
     }
     if (p.get('character')) {
         where.push(`EXISTS (SELECT 1 FROM work_characters wc
                             JOIN characters c ON c.id = wc.character_id
                             WHERE wc.work_id = w.id AND c.name = ? COLLATE NOCASE)`);
         binds.push(p.get('character'));
+        hasFilter = true;
+    }
+    const q = (p.get('q') || '').trim().slice(0, 100);
+    if (q) {
+        where.push('w.title LIKE ? COLLATE NOCASE');
+        binds.push(`%${q}%`);
+        hasFilter = true;
     }
 
+    // No filters/q: rank by likes then views so the JS pinning step below has
+    // a stable base order for "the rest". With filters/q: likes then recency
+    // — view_count would bias a narrow filtered result toward old favorites.
+    const orderSql = hasFilter
+        ? 'ORDER BY like_count DESC, w.created_at DESC, w.id'
+        : 'ORDER BY like_count DESC, w.view_count DESC, w.created_at DESC, w.id';
+
+    const selectBinds = sessionUser ? [sessionUser.id] : [];
     const sql = `
-        SELECT w.id, w.kind, w.title, w.genre, w.language, w.length, w.owner_id,
-               w.visibility, w.cover_image_url, w.created_at,
-               (SELECT s.display_text FROM scenes s
-                WHERE s.work_id = w.id ORDER BY s.idx LIMIT 1) AS excerpt,
-               (SELECT GROUP_CONCAT(we.emotion) FROM work_emotions we
-                WHERE we.work_id = w.id) AS emotions
+        SELECT ${workListColumnsSql(sessionUser)}
         FROM works w
+        JOIN users u ON u.id = w.owner_id
         ${where.length ? 'WHERE ' + where.join(' AND ') : ''}
-        ORDER BY w.created_at DESC, w.id
+        ${orderSql}
         LIMIT 100`;
 
-    const { results } = await env.DB.prepare(sql).bind(...binds).all();
-    return json({
-        works: results.map((r) => ({ ...r, emotions: r.emotions ? r.emotions.split(',') : [] })),
-    });
+    const { results } = await env.DB.prepare(sql).bind(...selectBinds, ...binds).all();
+
+    // A real search is a strong "interested in" signal for recommendations.
+    if (sessionUser && q) {
+        await env.DB.prepare(
+            `INSERT INTO user_events (id, user_id, kind, work_id, query, created_at) VALUES (?, ?, 'search', NULL, ?, ?)`
+        ).bind(`ue_${crypto.randomUUID()}`, sessionUser.id, q, Math.floor(Date.now() / 1000)).run();
+    }
+
+    let works = results.map(mapWorkRow);
+
+    // Plain listing only: pin the top 3 by view_count (ties by like_count) to
+    // the front, then leave the rest in the like/view/recency order already
+    // computed by the query above — one query, a stable JS partition on top.
+    if (!hasFilter) {
+        const byViews = [...works].sort((a, b) => b.view_count - a.view_count || b.like_count - a.like_count);
+        const pinnedIds = new Set(byViews.slice(0, 3).map((w) => w.id));
+        const pinned = byViews.filter((w) => pinnedIds.has(w.id));
+        const rest = works.filter((w) => !pinnedIds.has(w.id));
+        works = [...pinned, ...rest];
+    }
+
+    return json({ works });
+}
+
+// POST /api/works/:id/view — bumps view_count. No login required; visible to
+// anyone who can see the work (same rule as handleGetWork). Logs an 'open'
+// signal event when the viewer is signed in.
+async function handleTrackView(env, id, sessionUser) {
+    if (!env.DB) return json({ error: 'Database not configured' }, 501);
+
+    const work = await env.DB.prepare('SELECT owner_id, visibility FROM works WHERE id = ?').bind(id).first();
+    if (!work) return json({ error: 'Work not found' }, 404);
+    const ownedByViewer = sessionUser && sessionUser.id === work.owner_id;
+    if (work.visibility === 'private' && !ownedByViewer) return json({ error: 'Work not found' }, 404);
+
+    await env.DB.prepare('UPDATE works SET view_count = view_count + 1 WHERE id = ?').bind(id).run();
+    if (sessionUser) {
+        await env.DB.prepare(
+            `INSERT INTO user_events (id, user_id, kind, work_id, query, created_at) VALUES (?, ?, 'open', ?, NULL, ?)`
+        ).bind(`ue_${crypto.randomUUID()}`, sessionUser.id, id, Math.floor(Date.now() / 1000)).run();
+    }
+
+    const row = await env.DB.prepare('SELECT view_count FROM works WHERE id = ?').bind(id).first();
+    return json({ view_count: row.view_count });
+}
+
+// POST /api/works/:id/reaction  { reaction: 'like' | 'dislike' | null }
+// One reaction per (work, user); sending a new value replaces the old one,
+// null clears it. Requires sign-in — an anonymous "like" can't be undone by
+// its author later. Same visibility rule as viewing: you can't react to a
+// private work that isn't yours.
+async function handleReaction(env, id, sessionUser, body) {
+    if (!env.DB) return json({ error: 'Database not configured' }, 501);
+    if (!sessionUser) return json({ error: 'Log in to react' }, 401);
+
+    const work = await env.DB.prepare('SELECT owner_id, visibility FROM works WHERE id = ?').bind(id).first();
+    if (!work) return json({ error: 'Work not found' }, 404);
+    const ownedByViewer = sessionUser.id === work.owner_id;
+    if (work.visibility === 'private' && !ownedByViewer) return json({ error: 'Work not found' }, 404);
+
+    const reaction = body?.reaction ?? null;
+    if (reaction !== null && reaction !== 'like' && reaction !== 'dislike') {
+        return json({ error: "reaction must be 'like', 'dislike', or null" }, 400);
+    }
+
+    const now = Math.floor(Date.now() / 1000);
+    if (reaction === null) {
+        await env.DB.prepare('DELETE FROM work_reactions WHERE work_id = ? AND user_id = ?').bind(id, sessionUser.id).run();
+    } else {
+        // Flipping like<->dislike replaces the row (PRIMARY KEY (work_id, user_id)).
+        await env.DB.prepare(
+            'INSERT OR REPLACE INTO work_reactions (work_id, user_id, reaction, created_at) VALUES (?, ?, ?, ?)'
+        ).bind(id, sessionUser.id, reaction, now).run();
+        if (reaction === 'like') {
+            await env.DB.prepare(
+                `INSERT INTO user_events (id, user_id, kind, work_id, query, created_at) VALUES (?, ?, 'like', ?, NULL, ?)`
+            ).bind(`ue_${crypto.randomUUID()}`, sessionUser.id, id, now).run();
+        }
+    }
+
+    const counts = await env.DB.prepare(
+        `SELECT
+            (SELECT COUNT(*) FROM work_reactions WHERE work_id = ? AND reaction = 'like') AS like_count,
+            (SELECT COUNT(*) FROM work_reactions WHERE work_id = ? AND reaction = 'dislike') AS dislike_count`
+    ).bind(id, id).first();
+    const mine = await env.DB.prepare(
+        'SELECT reaction FROM work_reactions WHERE work_id = ? AND user_id = ?'
+    ).bind(id, sessionUser.id).first();
+
+    return json({ like_count: counts.like_count, dislike_count: counts.dislike_count, my_reaction: mine?.reaction ?? null });
+}
+
+// PATCH /api/works/:id  { visibility }  — owner-only.
+async function handleUpdateWork(env, id, sessionUser, body) {
+    if (!env.DB) return json({ error: 'Database not configured' }, 501);
+
+    const work = await env.DB.prepare('SELECT owner_id FROM works WHERE id = ?').bind(id).first();
+    if (!work) return json({ error: 'Work not found' }, 404);
+    if (!sessionUser || sessionUser.id !== work.owner_id) return json({ error: 'Not your work' }, 403);
+
+    const visibility = body?.visibility;
+    const allowedVisibility = ['private', 'unlisted', 'public'];
+    if (!allowedVisibility.includes(visibility)) {
+        return json({ error: "visibility must be 'private', 'unlisted', or 'public'" }, 400);
+    }
+
+    await env.DB.prepare('UPDATE works SET visibility = ? WHERE id = ?').bind(visibility, id).run();
+    return json({ id, visibility });
+}
+
+// DELETE /api/works/:id — owner-only. Children (scenes, work_emotions,
+// work_characters, narrations, animations) cascade via ON DELETE CASCADE.
+async function handleDeleteWork(env, id, sessionUser) {
+    if (!env.DB) return json({ error: 'Database not configured' }, 501);
+
+    const work = await env.DB.prepare('SELECT owner_id FROM works WHERE id = ?').bind(id).first();
+    if (!work) return json({ error: 'Work not found' }, 404);
+    if (!sessionUser || sessionUser.id !== work.owner_id) return json({ error: 'Not your work' }, 403);
+
+    await env.DB.prepare('DELETE FROM works WHERE id = ?').bind(id).run();
+    return json({ ok: true });
+}
+
+// GET /api/me/works — every work the signed-in user owns, any visibility.
+// Feeds the MyStories page.
+async function handleMyWorks(env, sessionUser) {
+    if (!env.DB) return json({ error: 'Database not configured' }, 501);
+    if (!sessionUser) return json({ error: 'Not signed in' }, 401);
+
+    const sql = `
+        SELECT ${workListColumnsSql(sessionUser)}
+        FROM works w
+        JOIN users u ON u.id = w.owner_id
+        WHERE w.owner_id = ?
+        ORDER BY w.created_at DESC, w.id
+        LIMIT 200`;
+
+    const { results } = await env.DB.prepare(sql).bind(sessionUser.id, sessionUser.id).all();
+    return json({ works: results.map(mapWorkRow) });
+}
+
+// GET /api/me/recommendations — basic content-based "recommended for you".
+// Signal: the genres/emotions of works this user has opened or liked (last
+// 200 matching events). Candidates: public works they don't own and haven't
+// opened, ranked by genre/emotion overlap with their signal, then by
+// like_count. No signal at all → the 6 most-liked public works they don't
+// own (the query below is already sorted that way).
+async function handleRecommendations(env, sessionUser) {
+    if (!env.DB) return json({ error: 'Database not configured' }, 501);
+    if (!sessionUser) return json({ error: 'Not signed in' }, 401);
+
+    const events = await env.DB.prepare(
+        `SELECT ue.kind, ue.work_id, w.genre,
+                (SELECT GROUP_CONCAT(we.emotion) FROM work_emotions we WHERE we.work_id = w.id) AS emotions
+         FROM user_events ue
+         JOIN works w ON w.id = ue.work_id
+         WHERE ue.user_id = ? AND ue.kind IN ('open','like')
+         ORDER BY ue.created_at DESC
+         LIMIT 200`
+    ).bind(sessionUser.id).all();
+
+    const openedIds = new Set();
+    const genreCounts = {};
+    const emotionCounts = {};
+    for (const e of events.results) {
+        if (e.kind === 'open') openedIds.add(e.work_id);
+        if (e.genre) genreCounts[e.genre] = (genreCounts[e.genre] || 0) + 1;
+        for (const emotion of e.emotions ? e.emotions.split(',') : []) {
+            emotionCounts[emotion] = (emotionCounts[emotion] || 0) + 1;
+        }
+    }
+    const hasSignal = Object.keys(genreCounts).length > 0 || Object.keys(emotionCounts).length > 0;
+
+    const candidatesSql = `
+        SELECT ${workListColumnsSql(sessionUser)}
+        FROM works w
+        JOIN users u ON u.id = w.owner_id
+        WHERE w.visibility = 'public' AND w.owner_id != ?
+        ORDER BY like_count DESC, w.view_count DESC, w.created_at DESC
+        LIMIT 200`;
+    const { results } = await env.DB.prepare(candidatesSql).bind(sessionUser.id, sessionUser.id).all();
+    const candidates = results.map(mapWorkRow).filter((w) => !openedIds.has(w.id));
+
+    if (!hasSignal) {
+        return json({ works: candidates.slice(0, 6) }); // already like_count-sorted
+    }
+
+    const scored = candidates
+        .map((w) => {
+            const genreScore = w.genre ? (genreCounts[w.genre] || 0) : 0;
+            const emotionScore = w.emotions.reduce((sum, e) => sum + (emotionCounts[e] || 0), 0);
+            return { w, score: genreScore + emotionScore };
+        })
+        .sort((a, b) => b.score - a.score || b.w.like_count - a.w.like_count);
+
+    return json({ works: scored.slice(0, 6).map((s) => s.w) });
 }
 
 // Escape text for safe placement inside an HTML attribute or element body.
@@ -639,7 +953,7 @@ async function handleGetWork(env, id, sessionUser) {
     const ownedByViewer = sessionUser && sessionUser.id === work.owner_id;
     if (work.visibility === 'private' && !ownedByViewer) return json({ error: 'Work not found' }, 404);
 
-    const [scenes, lines, cast, emotions] = await Promise.all([
+    const [scenes, lines, cast, emotions, counts, owner, myReaction] = await Promise.all([
         env.DB.prepare('SELECT * FROM scenes WHERE work_id = ? ORDER BY idx').bind(id).all(),
         env.DB.prepare(`SELECT sl.* FROM scene_lines sl
                         JOIN scenes s ON s.id = sl.scene_id
@@ -648,6 +962,15 @@ async function handleGetWork(env, id, sessionUser) {
                         JOIN characters c ON c.id = wc.character_id
                         WHERE wc.work_id = ?`).bind(id).all(),
         env.DB.prepare('SELECT emotion FROM work_emotions WHERE work_id = ?').bind(id).all(),
+        env.DB.prepare(
+            `SELECT
+                (SELECT COUNT(*) FROM work_reactions WHERE work_id = ? AND reaction = 'like') AS like_count,
+                (SELECT COUNT(*) FROM work_reactions WHERE work_id = ? AND reaction = 'dislike') AS dislike_count`
+        ).bind(id, id).first(),
+        env.DB.prepare('SELECT handle FROM users WHERE id = ?').bind(work.owner_id).first(),
+        sessionUser
+            ? env.DB.prepare('SELECT reaction FROM work_reactions WHERE work_id = ? AND user_id = ?').bind(id, sessionUser.id).first()
+            : null,
     ]);
 
     const linesByScene = {};
@@ -660,6 +983,10 @@ async function handleGetWork(env, id, sessionUser) {
         emotions: emotions.results.map((e) => e.emotion),
         characters: cast.results,
         scenes: scenes.results.map((s) => ({ ...s, lines: linesByScene[s.id] || [] })),
+        like_count: counts.like_count,
+        dislike_count: counts.dislike_count,
+        my_reaction: myReaction?.reaction ?? null,
+        owner_handle: owner?.handle ?? null,
     });
 }
 
@@ -901,6 +1228,11 @@ async function handleMedia(env, path) {
 // Saving requires a signed-in owner. The 'guest' system user (migration
 // 0004) is legacy-only now: existing guest-owned rows keep working, but
 // nothing new is written there — a logged-out visitor gets a 401 instead.
+// Ownership: `ownerId` below is always the session user, so a story
+// generated from someone's prompt and saved while they're logged in is
+// owned by them, full stop — never by 'lisa'. The 'lisa' owner_id is
+// reserved for the seed/built-in rows from migrations 0001-0002; nothing
+// in this handler can ever write it.
 async function handleCreateWork(env, request, body) {
     if (!env.DB) return json({ error: 'Database not configured' }, 501);
 
@@ -1021,11 +1353,31 @@ export default {
                 }
                 if (path === '/generate-story') return await handleGenerateStory(env, anthropic, body);
                 if (path === '/api/works') return await handleCreateWork(env, request, body);
+                if (path.startsWith('/api/works/') && path.endsWith('/view')) {
+                    const id = decodeURIComponent(path.slice('/api/works/'.length, -'/view'.length));
+                    return await handleTrackView(env, id, await getSessionUser(env, request));
+                }
+                if (path.startsWith('/api/works/') && path.endsWith('/reaction')) {
+                    const id = decodeURIComponent(path.slice('/api/works/'.length, -'/reaction'.length));
+                    return await handleReaction(env, id, await getSessionUser(env, request), body);
+                }
                 if (path === '/auth/logout') return await handleAuthLogout(env, request);
+            }
+
+            if (method === 'PATCH') {
+                if (path.startsWith('/api/works/')) {
+                    const body = await request.json().catch(() => ({}));
+                    const id = decodeURIComponent(path.slice('/api/works/'.length));
+                    return await handleUpdateWork(env, id, await getSessionUser(env, request), body);
+                }
             }
 
             if (method === 'DELETE') {
                 if (path === '/api/me') return await handleDeleteMe(env, request);
+                if (path.startsWith('/api/works/')) {
+                    const id = decodeURIComponent(path.slice('/api/works/'.length));
+                    return await handleDeleteWork(env, id, await getSessionUser(env, request));
+                }
             }
 
             if (method === 'GET') {
@@ -1034,6 +1386,8 @@ export default {
                     return await handleSharePage(env, url, decodeURIComponent(path.slice('/s/'.length)));
                 }
                 if (path === '/api/works') return await handleListWorks(env, url, await getSessionUser(env, request));
+                if (path === '/api/me/works') return await handleMyWorks(env, await getSessionUser(env, request));
+                if (path === '/api/me/recommendations') return await handleRecommendations(env, await getSessionUser(env, request));
                 if (path.startsWith('/api/works/') && path.endsWith('/narration')) {
                     const id = decodeURIComponent(path.slice('/api/works/'.length, -'/narration'.length));
                     return await handleGetNarration(env, id, url.searchParams.get('voice'), await getSessionUser(env, request));

--- a/myproject/worker/migrations/0006_engagement.sql
+++ b/myproject/worker/migrations/0006_engagement.sql
@@ -1,0 +1,21 @@
+ALTER TABLE works ADD COLUMN view_count INTEGER NOT NULL DEFAULT 0;
+
+-- One reaction per user per work; flipping like<->dislike replaces the row.
+CREATE TABLE work_reactions (
+    work_id    TEXT NOT NULL REFERENCES works(id) ON DELETE CASCADE,
+    user_id    TEXT NOT NULL REFERENCES users(id),
+    reaction   TEXT NOT NULL CHECK (reaction IN ('like','dislike')),
+    created_at INTEGER NOT NULL,
+    PRIMARY KEY (work_id, user_id)
+);
+
+-- Lightweight signal log driving "recommended for you" (opens, searches, likes).
+CREATE TABLE user_events (
+    id         TEXT PRIMARY KEY,
+    user_id    TEXT NOT NULL REFERENCES users(id),
+    kind       TEXT NOT NULL CHECK (kind IN ('open','search','like')),
+    work_id    TEXT REFERENCES works(id) ON DELETE CASCADE,
+    query      TEXT,
+    created_at INTEGER NOT NULL
+);
+CREATE INDEX idx_user_events_user ON user_events(user_id, created_at);


### PR DESCRIPTION
Two commits: the engagement/image backend (`6d53f96`) and the full frontend batch (`1989825`).

## Backend

- **Migration `0006_engagement.sql`** — `works.view_count`, `work_reactions` (one like/dislike per user per story), `user_events` (opens/searches/likes — the recommendation signal).
- **Endpoints**: `POST /api/works/:id/view`, `POST /api/works/:id/reaction`, owner-only `PATCH`/`DELETE /api/works/:id`, `?q=` title search on the listing, `GET /api/me/works`, `GET /api/me/recommendations`. Every listing row now carries views, like/dislike counts, `owner_handle`, and the viewer's own reaction.
- **Listing order**: the 3 most-viewed pinned first, then most-liked — as specced.
- **Higgsfield image generation**: `recraft_v4_1` at 1344×768 primary (when `HF_CREDENTIALS` is set), GPT Image 2 fallback. Eight cartoon styles + server-side "surprise" pick; every prompt hard-suffixed *"absolutely no photorealism, no real people"*. Note: Higgsfield doesn't publish the Recraft REST path — the integration follows their documented Soul submit+poll pattern and is flagged for confirmation on first live call (the fallback keeps covers working regardless).
- All query logic verified against a scratch DB built from migrations 0001→0006 (ordering rule, reaction flip, owner guards, cascade delete, recommendation scoring).

## Frontend

- **Shared card component** (`js/cards.js`): ⋮ menu (Read / Copy link, plus **Make public/unlisted/private** and **Delete** when you own the story), 👍/👎 with counts, 👁 views, mini owner tag (LISA 1000 mark on seeds, initial-avatar + handle otherwise).
- **My Stories** (`mystories.html`, tab appears only when logged in): your works with private ones hidden behind a clearly-visible "🔒 Show private stories" checkbox, plus "Recommended for you" from your opens/searches/likes. Logged-out visitors get a friendly gate.
- **Library search** — debounced title search above the filters.
- **Reader**: view counted on open, like/dislike under the title, word-highlight now **warm amber**.
- **Create page**: 🎨 art-style picker (8 cartoon styles + ⭐ Surprise me), "Illustrated in: <style>" caption, and a redesigned save dialog — tactile Public/Unlisted/Private option cards, amber confirm.
- **Starry night**: deepened fixed night-sky gradient, denser parallax star field, two slow shooting stars, and a hand-drawn SVG rocket floating in the hero (hidden on phones, honors reduced-motion). **Spot retired from the homepage** (featured slot now "Sue's Thoughtful Act").

## After merging (dashboard)

1. Run `worker/migrations/0006_engagement.sql` in the D1 console.
2. Set `HF_CREDENTIALS` (`KEY_ID:KEY_SECRET` from cloud.higgsfield.ai) as a Worker secret to activate Recraft covers — optional; GPT Image 2 covers everything until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JpFXVHt85zDP6Bwdjrenoc

---
_Generated by [Claude Code](https://claude.ai/code/session_01JpFXVHt85zDP6Bwdjrenoc)_