### PR TITLE
Apply UX review: clarity, contrast, density, and card consistency

### DIFF
--- a/myproject/public/create-story.html
+++ b/myproject/public/create-story.html
@@ -19,7 +19,7 @@
                     <li><a href="create-story.html">Create Story</a></li>
                     <li>
                         <select id="nativeLanguage">
-                            <option value="default">I speak...</option>
+                            <option value="default">Translate into…</option>
                             <option value="en">English</option>
                             <option value="fr">Français</option>
                             <option value="es">Español</option>
@@ -31,7 +31,7 @@
                         <input type="text" id="otherLanguage" class="hidden" placeholder="Please specify your language">
                     </li>
                     <li>
-                        <div id="translation-toggle" class="translation-toggle" title="Translate mode: when on, double-clicking a word translates it into your language instead of defining it" aria-label="Toggle translate mode" role="button">T</div>
+                        <div id="translation-toggle" class="translation-toggle" title="Translate mode: when on, double-clicking a word translates it into your language instead of defining it" aria-label="Toggle translate mode" role="button">🌐</div>
                     </li>
                     <li id="auth-nav"></li>
                 </ul>
@@ -49,8 +49,8 @@
     </header>
     <main class="create-main">
         <section id="create-story-section" class="option-tabs">
-            <button id="takeMattersButton">✨ LISA's Story</button>
-            <button id="generateStoryButton">✍️ My Story</button>
+            <button id="takeMattersButton" title="Give LISA a spark — she invents everything">✨ LISA's Story</button>
+            <button id="generateStoryButton" title="Your idea, your characters — LISA builds on them">✍️ My Story</button>
         </section>
 
         <div class="style-picker" title="Every illustration stays cartoonish — pick the flavour">

--- a/myproject/public/css/style.css
+++ b/myproject/public/css/style.css
@@ -3,8 +3,9 @@
     --bg-raise: rgba(255, 255, 255, 0.06);
     --bg-raise-2: rgba(255, 255, 255, 0.02);
     --text: #EDEAF7;
-    --text-muted: #A79FC4;
-    --text-faint: #6E668D;
+    /* Lifted for WCAG AA on the night background — muted ≈ 8:1, faint ≈ 5:1 */
+    --text-muted: #B3ABD1;
+    --text-faint: #8B82AC;
     --purple: #8B5CF6;
     --purple-deep: #6D28D9;
     --lavender: #C4B5FD;
@@ -15,6 +16,13 @@
 }
 
 * { box-sizing: border-box; }
+
+/* Keyboard users always see where they are — amber ring on anything focusable */
+:focus-visible {
+    outline: 2px solid var(--amber);
+    outline-offset: 2px;
+    border-radius: 6px;
+}
 
 body {
     font-family: 'Karla', sans-serif;
@@ -527,7 +535,8 @@ header { background: transparent; }
 .page-header {
     position: relative;
     overflow: hidden;
-    padding: 64px 24px 46px;
+    /* Kept shallow so the actual content starts within the first screen */
+    padding: 38px 24px 28px;
     text-align: center;
     background: radial-gradient(ellipse 60% 70% at 50% -10%, rgba(109, 40, 217, 0.45), transparent 70%);
 }
@@ -535,8 +544,8 @@ header { background: transparent; }
 .page-header-inner { position: relative; z-index: 2; }
 
 .page-header h1 {
-    margin: 0 0 12px;
-    font-size: 48px;
+    margin: 0 0 10px;
+    font-size: 42px;
 }
 
 .page-header p {
@@ -1246,9 +1255,17 @@ button.ghost.save-locked:hover {
     padding: 18px 22px 22px;
 }
 
+/* Clamped so every card keeps the same rhythm: titles two lines max,
+   excerpts three — footers stay aligned across the whole grid. */
 .story-card h2 {
     margin: 0 0 8px;
     font-size: 20px;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    min-height: 2.5em;
+    line-height: 1.25;
 }
 
 .story-card p {
@@ -1257,6 +1274,10 @@ button.ghost.save-locked:hover {
     font-size: 14px;
     line-height: 1.6;
     color: var(--text-muted);
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
 }
 
 .story-card button { align-self: flex-start; font-size: 14px; padding: 10px 20px; }
@@ -1643,19 +1664,42 @@ footer button#aboutButton:hover { color: #fff; transform: none; box-shadow: none
 .library-search {
     max-width: 1140px;
     width: 100%;
-    margin: 18px auto 6px;
+    margin: 14px auto 6px;
     padding: 0 24px;
     box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
 }
 
 .library-search.hidden { display: none; }
 
 .library-search input {
+    flex: 1;
+    min-width: 200px;
     max-width: 420px;
     border-radius: 999px;
     padding: 12px 20px;
     margin-bottom: 0;
     background-color: rgba(23, 17, 48, 0.8);
+}
+
+.library-search select {
+    width: auto;
+    margin-bottom: 0;
+    padding: 10px 34px 10px 16px;
+    border-radius: 999px;
+    font-size: 14px;
+    background-color: rgba(23, 17, 48, 0.8);
+}
+
+.results-count {
+    margin-left: auto;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-faint);
+    white-space: nowrap;
 }
 
 /* ---------- Card engagement (owner tag, views, reactions, kebab) ---------- */

--- a/myproject/public/index.html
+++ b/myproject/public/index.html
@@ -19,7 +19,7 @@
                     <li><a href="create-story.html">Create Story</a></li>
                     <li>
                         <select id="nativeLanguage">
-                            <option value="default">I speak...</option>
+                            <option value="default">Translate into…</option>
                             <option value="en">English</option>
                             <option value="fr">Français</option>
                             <option value="es">Español</option>
@@ -31,7 +31,7 @@
                         <input type="text" id="otherLanguage" class="hidden" placeholder="Please specify your language">
                     </li>
                     <li>
-                        <div id="translation-toggle" class="translation-toggle" title="Translate mode: when on, double-clicking a word translates it into your language instead of defining it" aria-label="Toggle translate mode" role="button">T</div>
+                        <div id="translation-toggle" class="translation-toggle" title="Translate mode: when on, double-clicking a word translates it into your language instead of defining it" aria-label="Toggle translate mode" role="button">🌐</div>
                     </li>
                     <li id="auth-nav"></li>
                 </ul>
@@ -148,7 +148,7 @@
             <li><span class="key-chip">🔊 Read aloud</span><span>Pick Lisa or Adam and hear the story streamed aloud instantly.</span></li>
             <li><span class="key-chip">🎙 Record</span><span>Narrate the story yourself and play back your recording.</span></li>
             <li><span class="key-chip">👆 Double-click</span><span>Double-click any word for its definition and pronunciation.</span></li>
-            <li><span class="key-chip">T&nbsp;Translate</span><span>Turn on the <strong>T</strong> toggle and pick "I speak…" — then double-click words or press Translate.</span></li>
+            <li><span class="key-chip">🌐&nbsp;Translate</span><span>Turn on the <strong>🌐</strong> toggle and pick "Translate into…" — then double-click words or press Translate.</span></li>
             <li><span class="key-chip">✨ Create</span><span>Generate your own illustrated story on the <a href="create-story.html">Create Story</a> page.</span></li>
         </ul>
     </section>

--- a/myproject/public/js/cards.js
+++ b/myproject/public/js/cards.js
@@ -51,8 +51,11 @@ window.LisaCards = (function () {
         const buttons = {};
 
         function paint() {
+            // Zero counts stay hidden — a wall of "0 / 0" makes new stories
+            // feel dead; the icons alone still invite the first reaction.
             for (const kind of ['like', 'dislike']) {
-                buttons[kind].textContent = `${kind === 'like' ? '👍' : '👎'} ${counts[kind]}`;
+                const n = counts[kind];
+                buttons[kind].textContent = `${kind === 'like' ? '👍' : '👎'}${n > 0 ? ' ' + n : ''}`;
                 buttons[kind].classList.toggle('active', mine === kind);
             }
         }
@@ -232,10 +235,12 @@ window.LisaCards = (function () {
             const meta = document.createElement('div');
             meta.className = 'card-meta';
             meta.appendChild(ownerTag(work));
-            const views = document.createElement('span');
-            views.className = 'view-count';
-            views.textContent = `👁 ${work.view_count || 0}`;
-            meta.appendChild(views);
+            if ((work.view_count || 0) > 0) {
+                const views = document.createElement('span');
+                views.className = 'view-count';
+                views.textContent = `👁 ${work.view_count}`;
+                meta.appendChild(views);
+            }
             body.appendChild(meta);
         }
 
@@ -246,7 +251,7 @@ window.LisaCards = (function () {
         const footer = document.createElement('div');
         footer.className = 'card-footer';
         const button = document.createElement('button');
-        button.textContent = 'Read More →';
+        button.textContent = 'Read story →';
         footer.appendChild(button);
         if (work.id) footer.appendChild(reactionBar(work, me));
         body.appendChild(footer);

--- a/myproject/public/js/loadStories.js
+++ b/myproject/public/js/loadStories.js
@@ -4,9 +4,32 @@
 // Signed-in viewer (or null), shared from auth.js — gates reactions and
 // unlocks the owner options in each card's ⋮ menu.
 let libraryMe = null;
+// Last fetched result set, re-sorted client-side when the sort changes.
+let lastWorks = [];
+
+function sortWorks(works) {
+    const mode = document.getElementById('librarySort')?.value || 'recommended';
+    if (mode === 'recommended') return works; // server order: top-viewed pinned, then most liked
+    const sorted = [...works];
+    if (mode === 'newest') sorted.sort((a, b) => (b.created_at || 0) - (a.created_at || 0));
+    if (mode === 'views') sorted.sort((a, b) => (b.view_count || 0) - (a.view_count || 0));
+    if (mode === 'likes') sorted.sort((a, b) => (b.like_count || 0) - (a.like_count || 0));
+    return sorted;
+}
+
+function anyFilterActive() {
+    return Object.values(libraryFilters).some(Boolean);
+}
 
 function renderWorks(mainElement, works) {
+    lastWorks = works;
     mainElement.innerHTML = '';
+
+    const count = document.getElementById('resultsCount');
+    if (count) count.textContent = `${works.length} ${works.length === 1 ? 'story' : 'stories'}`;
+    const clear = document.getElementById('clearFilters');
+    if (clear) clear.hidden = !anyFilterActive();
+
     if (!works.length) {
         const empty = document.createElement('p');
         empty.className = 'library-empty';
@@ -16,7 +39,7 @@ function renderWorks(mainElement, works) {
         mainElement.appendChild(empty);
         return;
     }
-    works.forEach(work => LisaCards.buildWorkCard(mainElement, work, { me: libraryMe }));
+    sortWorks(works).forEach(work => LisaCards.buildWorkCard(mainElement, work, { me: libraryMe }));
 }
 
 // Active filter state; empty string = "All" for that group.
@@ -46,20 +69,50 @@ function buildGenreChips(works) {
     });
 }
 
+function paintChipStates() {
+    document.querySelectorAll('#library-filters .chip').forEach((chip) => {
+        chip.setAttribute('aria-pressed', chip.classList.contains('active') ? 'true' : 'false');
+    });
+}
+
 function activateFilterBar(mainElement) {
     const bar = document.getElementById('library-filters');
     bar.classList.remove('hidden');
+    paintChipStates();
     bar.addEventListener('click', async (event) => {
         const chip = event.target.closest('.chip');
         if (!chip) return;
         const group = chip.closest('.filter-group');
         group.querySelectorAll('.chip').forEach(c => c.classList.remove('active'));
         chip.classList.add('active');
+        paintChipStates();
         libraryFilters[group.getAttribute('data-param')] = chip.getAttribute('data-value');
         try {
             renderWorks(mainElement, await fetchWorks());
         } catch (error) {
             console.error('Error filtering stories:', error);
+        }
+    });
+
+    // Sort re-orders the already-fetched set — no refetch needed.
+    const sortSelect = document.getElementById('librarySort');
+    if (sortSelect) sortSelect.addEventListener('change', () => renderWorks(mainElement, lastWorks));
+
+    // Clear filters: back to All everywhere, empty search, refetch.
+    const clear = document.getElementById('clearFilters');
+    if (clear) clear.addEventListener('click', async () => {
+        for (const key of Object.keys(libraryFilters)) libraryFilters[key] = '';
+        const search = document.getElementById('librarySearch');
+        if (search) search.value = '';
+        document.querySelectorAll('#library-filters .filter-group').forEach((group) => {
+            group.querySelectorAll('.chip').forEach((c) =>
+                c.classList.toggle('active', c.getAttribute('data-value') === ''));
+        });
+        paintChipStates();
+        try {
+            renderWorks(mainElement, await fetchWorks());
+        } catch (error) {
+            console.error('Error clearing filters:', error);
         }
     });
 }

--- a/myproject/public/library.html
+++ b/myproject/public/library.html
@@ -19,7 +19,7 @@
                     <li><a href="create-story.html">Create Story</a></li>
                     <li>
                         <select id="nativeLanguage">
-                            <option value="default">I speak...</option>
+                            <option value="default">Translate into…</option>
                             <option value="en">English</option>
                             <option value="fr">Français</option>
                             <option value="es">Español</option>
@@ -31,7 +31,7 @@
                         <input type="text" id="otherLanguage" class="hidden" placeholder="Please specify your language">
                     </li>
                     <li>
-                        <div id="translation-toggle" class="translation-toggle" title="Translate mode: when on, double-clicking a word translates it into your language instead of defining it" aria-label="Toggle translate mode" role="button">T</div>
+                        <div id="translation-toggle" class="translation-toggle" title="Translate mode: when on, double-clicking a word translates it into your language instead of defining it" aria-label="Toggle translate mode" role="button">🌐</div>
                     </li>
                     <li id="auth-nav"></li>
                 </ul>
@@ -49,7 +49,15 @@
     </header>
 
     <div class="library-search hidden">
-        <input type="search" id="librarySearch" placeholder="🔍 Search stories…" autocomplete="off" aria-label="Search stories by title">
+        <input type="search" id="librarySearch" placeholder="Search stories…" autocomplete="off" aria-label="Search stories by title">
+        <select id="librarySort" aria-label="Sort stories">
+            <option value="recommended">Sort: Recommended</option>
+            <option value="newest">Sort: Newest</option>
+            <option value="views">Sort: Most viewed</option>
+            <option value="likes">Sort: Most liked</option>
+        </select>
+        <button type="button" id="clearFilters" class="chip" hidden>✕ Clear filters</button>
+        <span id="resultsCount" class="results-count" aria-live="polite"></span>
     </div>
 
     <section id="library-filters" class="filter-bar hidden" aria-label="Filter stories">

--- a/myproject/public/mystories.html
+++ b/myproject/public/mystories.html
@@ -19,7 +19,7 @@
                     <li><a href="create-story.html">Create Story</a></li>
                     <li>
                         <select id="nativeLanguage">
-                            <option value="default">I speak...</option>
+                            <option value="default">Translate into…</option>
                             <option value="en">English</option>
                             <option value="fr">Français</option>
                             <option value="es">Español</option>
@@ -31,7 +31,7 @@
                         <input type="text" id="otherLanguage" class="hidden" placeholder="Please specify your language">
                     </li>
                     <li>
-                        <div id="translation-toggle" class="translation-toggle" title="Translate mode: when on, double-clicking a word translates it into your language instead of defining it" aria-label="Toggle translate mode" role="button">T</div>
+                        <div id="translation-toggle" class="translation-toggle" title="Translate mode: when on, double-clicking a word translates it into your language instead of defining it" aria-label="Toggle translate mode" role="button">🌐</div>
                     </li>
                     <li id="auth-nav"></li>
                 </ul>

--- a/myproject/public/story.html
+++ b/myproject/public/story.html
@@ -19,7 +19,7 @@
                     <li><a href="create-story.html">Create Story</a></li>
                     <li>
                         <select id="nativeLanguage">
-                            <option value="default">I speak...</option>
+                            <option value="default">Translate into…</option>
                             <option value="en">English</option>
                             <option value="fr">Français</option>
                             <option value="es">Español</option>
@@ -31,7 +31,7 @@
                         <input type="text" id="otherLanguage" class="hidden" placeholder="Please specify your language">
                     </li>
                     <li>
-                        <div id="translation-toggle" class="translation-toggle" title="Translate mode: when on, double-clicking a word translates it into your language instead of defining it" aria-label="Toggle translate mode" role="button">T</div>
+                        <div id="translation-toggle" class="translation-toggle" title="Translate mode: when on, double-clicking a word translates it into your language instead of defining it" aria-label="Toggle translate mode" role="button">🌐</div>
                     </li>
                     <li id="auth-nav"></li>
                 </ul>


### PR DESCRIPTION
Implements the high-value items from the external UX review, in its own priority order.

## Clarity (the review's #1 finding)

The reviewer mistook the round "T" translate toggle for a user avatar — if an expert misreads it, users will. Fixes:
- Translate toggle is now a **🌐 globe** (breaks the letter-in-circle = avatar pattern) on all five pages, Quick guide updated to match
- The ambiguous **"I speak…"** dropdown is now labeled by what it actually does: **"Translate into…"**
- "LISA's Story" / "My Story" tabs gained explanatory tooltips

## Contrast (WCAG AA)

`--text-muted` and `--text-faint` lifted (≈8:1 and ≈5:1 on the night background) — card excerpts, owner names, filter labels, counts, and placeholders all benefit without touching the aesthetic.

## Density

Page headers compressed (~35% shorter) so Library content and the Create form start within the first screen; the search/sort toolbar sits tight under the heading.

## Library scanning

- **Sort control**: Recommended (server order) / Newest / Most viewed / Most liked — client-side re-sort, no refetch
- **Results count** ("24 stories", `aria-live`) and a **✕ Clear filters** chip that appears only when filters are active
- Filter chips now carry `aria-pressed`
- Search placeholder de-emojied (the 🔍 read as a flag to the reviewer)

## Cards

- Titles clamped to 2 lines, excerpts to 3 — footers now align across the whole grid
- "Read More" → **"Read story →"**
- **Zero counts hidden**: 👍/👎 show bare icons until the first reaction; 👁 appears only once a story has views (a wall of `0/0` made new stories feel dead)

## Accessibility

Global `:focus-visible` amber ring for keyboard users (reduced-motion support already shipped in the previous PR).

Deferred to a future pass (bigger jobs, flagged in review): mobile filter drawer + responsive overhaul, loading skeletons, image `srcset`/CDN pipeline, form-level validation states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JpFXVHt85zDP6Bwdjrenoc

---
_Generated by [Claude Code](https://claude.ai/code/session_01JpFXVHt85zDP6Bwdjrenoc)_